### PR TITLE
JP - Copy Image Resources Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 #sbt-microsites
 
+## Prerequisites
+
+* [Jekyll](https://jekyllrb.com/):
+
+```bash
+gem install jekyll
+```
+
 ### Steps:
 
 Add plugin in `project/plugins.sbt`:

--- a/src/main/scala/microsites/FileHelper.scala
+++ b/src/main/scala/microsites/FileHelper.scala
@@ -1,0 +1,67 @@
+package microsites
+
+import java.io.File
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.Files.copy
+import java.nio.file.Path
+import java.nio.file.Paths.get
+
+trait FileHelper {
+
+  implicit class FileNameImplicit(filename: String) {
+    def toPath = get(filename)
+
+    def toFile = new File(filename.fixPath)
+
+    def fixPath = filename.replaceAll("/", File.separator)
+  }
+
+  def getPathWithSlash(f: File): String =
+    f.getAbsolutePath + (if (f.getAbsolutePath.endsWith(File.separator)) "" else File.separator)
+
+  def copyFilesRecursively(sourcePath: String, targetDirPath: String): Unit = {
+
+    val source = sourcePath.toFile
+    fetchFilesRecursively(source) foreach { f =>
+      val filePath = f.getAbsolutePath.replaceAll(sourcePath, "")
+      copyFile(f, s"$targetDirPath$filePath".toFile)
+    }
+  }
+
+  def fetchFilesRecursively(directory: File): List[File] = {
+
+    val listFiles = Option(directory.listFiles)
+
+    listFiles match {
+      case Some(firstLevelFiles) =>
+        val onlyFirstLevelFiles = firstLevelFiles filter (_.isFile)
+        val firstLevelDirectories = firstLevelFiles filter (_.isDirectory)
+
+        (onlyFirstLevelFiles ++ firstLevelDirectories.flatMap(d => fetchFilesRecursively(d))).toList
+      case None =>
+        Nil
+    }
+  }
+
+  def copyFile(sourceFile: File, targetFile: File): Path = {
+
+    createFileIfNotExists(targetFile)
+
+    copy(sourceFile.toPath, targetFile.toPath, REPLACE_EXISTING)
+  }
+
+  def createFilePathIfNotExists(f: String): File =
+    createFileIfNotExists(f.toFile)
+
+  def createFileIfNotExists(f: File): File = {
+
+    if (!f.exists()) {
+      if (!f.getParentFile.exists())
+        f.getParentFile.mkdirs()
+      f.createNewFile()
+    }
+    f
+  }
+}
+
+object FileHelper extends FileHelper

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -1,0 +1,14 @@
+package microsites
+
+import sbt._
+
+trait MicrositeKeys {
+  val microsite = taskKey[Seq[File]]("Create microsite files")
+  val micrositeName = settingKey[String]("Microsite name")
+  val micrositeDescription = settingKey[String]("Microsite description")
+  val micrositeAuthor = settingKey[String]("Microsite author")
+  val micrositeHomepage = settingKey[String]("Microsite homepage")
+  val micrositeTwitter = settingKey[String]("Microsite twitter")
+  val micrositeHighlightTheme = settingKey[String]("Microsite Highlight Theme")
+}
+object MicrositeKeys extends MicrositeKeys


### PR DESCRIPTION
This PR provides:

* Prerequisites section
* Recursive utility to copy all the resources under `/path/to/projectpath/src/main/resources/microsite` to `resource_managed/main/jekyll/img` folder (according to the original structure).

Please, @rafaparadela could you review? Thanks.