### PR TITLE
"Kazari" plugin rough draft

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,12 +38,24 @@ lazy val micrositeSettings = Seq(
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md"
 )
 
+val circeVersion = "0.5.2"
+
 lazy val jsSettings = Seq(
   scalaJSStage in Global := FastOptStage,
   parallelExecution := false,
   scalaJSUseRhino := false,
   requiresDOM := false,
-  jsEnv := NodeJSEnv().value
+  jsEnv := NodeJSEnv().value,
+  libraryDependencies ++= Seq(
+    "org.scala-js" %%% "scalajs-dom" % "0.9.0",
+    "be.doeraene" %%% "scalajs-jquery" % "0.9.0",
+    "com.lihaoyi" %%% "upickle" % "0.4.1"
+  ),
+  jsDependencies +=
+      "org.webjars" % "jquery" % "2.1.3" / "2.1.3/jquery.js",
+  resolvers += Resolver.url(
+    "bintray-sbt-plugin-releases",
+    url("https://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 )
 
 lazy val testSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,14 @@ lazy val micrositeSettings = Seq(
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md"
 )
 
+lazy val jsSettings = Seq(
+  scalaJSStage in Global := FastOptStage,
+  parallelExecution := false,
+  scalaJSUseRhino := false,
+  requiresDOM := false,
+  jsEnv := NodeJSEnv().value
+)
+
 lazy val testSettings =
   ScriptedPlugin.scriptedSettings ++ Seq(
     scriptedDependencies <<= (compile in Test) map { (analysis) =>
@@ -99,3 +107,9 @@ lazy val docs = (project in file("docs"))
   .settings(moduleName := "docs")
   .enablePlugins(MicrositesPlugin)
   .enablePlugins(BuildInfoPlugin)
+
+lazy val js = (project in file("js"))
+  .settings(moduleName := "sbt-microsites-js")
+  .settings(commonSettings:_*)
+  .settings(jsSettings:_*)
+  .enablePlugins(ScalaJSPlugin)

--- a/js/src/main/scala/kazari/KazariPlugin.scala
+++ b/js/src/main/scala/kazari/KazariPlugin.scala
@@ -1,0 +1,83 @@
+package kazari
+
+import org.scalajs.dom
+import org.scalajs.dom._
+
+import scala.scalajs.js.JSApp
+import scala.scalajs.js.annotation.JSExport
+import dom.ext.PimpedNodeList
+import kazari.model.{EvaluatorConfig, EvaluatorDependency, EvaluatorRequest}
+import org.scalajs.jquery.{JQueryAjaxSettings, JQueryXHR, jQuery}
+
+import scala.scalajs.js
+import upickle.default._
+
+object KazariPlugin extends JSApp with DOMHelper {
+  val codeExcludeClass = "code-exclude"
+  lazy val codeSnippets = document.querySelectorAll(s"code.language-scala:not(.$codeExcludeClass)")
+
+  @JSExport
+  def main(): Unit = { }
+
+  @JSExport
+  def decorateCode(config: EvaluatorConfig): Unit = {
+    val textSnippets = generateCodeTextSnippets()
+
+    codeSnippets.zipWithIndex foreach { case (node, i) =>
+      appendButton(node, "Evaluate", onClickFunction = (e: dom.MouseEvent) => {
+        val snippet = textSnippets.lift(i + 1)
+        val request = generateEvalRequest(snippet.getOrElse(""), Seq[String](), Seq[EvaluatorDependency]())
+
+        requestEvaluationOfSnippet(request,
+          config.url,
+          config.authToken,
+          (data: js.Any, textStatus: String, jqHXR: JQueryXHR) => {
+            println(s"Connection to evaluator established: $textStatus")
+          },
+          (jqHXR: JQueryXHR, status: String, error: String) => {
+            println(s"Error while connecting with remote evaluator: $error")
+          }
+        )
+      });
+    }
+  }
+
+  def generateCodeTextSnippets() = {
+    codeSnippets.map(_.textContent)
+        .scanLeft("")((currentItem, result) => currentItem + result)
+  }
+
+  def requestEvaluationOfSnippet(snippet: String,
+      url: String,
+      token: String,
+      success: (js.Any, String, JQueryXHR) => Unit,
+      failure: (JQueryXHR, String, String) => Unit) = {
+    val settings = js.Dynamic.literal(
+      `type` = "POST",
+      url = url,
+      beforeSend = (xhrObj: JQueryXHR) => {
+        xhrObj.setRequestHeader("X-Scala-Eval-Api-Token", token)
+        xhrObj.setRequestHeader("Content-Type", "application/json")
+      },
+      data = snippet,
+      success = success,
+      error = failure
+    ).asInstanceOf[JQueryAjaxSettings]
+
+    jQuery.ajax(settings)
+  }
+
+  def generateEvalRequest(snippet: String, resolvers: Seq[String], dependencies: Seq[EvaluatorDependency]): String =
+    write(EvaluatorRequest(resolvers, dependencies, snippet))
+}
+
+trait DOMHelper {
+  def appendButton[T](targetNode: dom.Node, title: String, onClickFunction: Function[_, T], id: Option[String] = None): dom.Node = {
+    val btnNode = document.createElement("button")
+    btnNode.appendChild(document.createTextNode(title))
+    btnNode.setAttribute("type", "button")
+    btnNode.setAttribute("id", id.getOrElse(""))
+    btnNode.addEventListener("click", onClickFunction)
+    targetNode.appendChild(btnNode)
+  }
+}

--- a/js/src/main/scala/kazari/model/EvaluatorConfig.scala
+++ b/js/src/main/scala/kazari/model/EvaluatorConfig.scala
@@ -1,0 +1,6 @@
+package kazari.model
+
+import scala.scalajs.js.annotation.JSExport
+
+@JSExport
+case class EvaluatorConfig(url: String, authToken: String)

--- a/js/src/main/scala/kazari/model/EvaluatorRequest.scala
+++ b/js/src/main/scala/kazari/model/EvaluatorRequest.scala
@@ -1,0 +1,4 @@
+package kazari.model
+
+case class EvaluatorRequest(resolvers: Seq[String], dependencies: Seq[EvaluatorDependency], code: String)
+case class EvaluatorDependency(groupId: String, artifactId: String, version: String)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ libraryDependencies <+= sbtVersion("org.scala-sbt" % "scripted-plugin" % _)
 // Plugin inception dependency to be able to generate the sbt-microsites' microsite
 addSbtPlugin("com.fortysevendeg" % "sbt-microsites" % "0.2.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.12")


### PR DESCRIPTION
This PR introduces "Kazari", a Scala.JS-powered plugin that will allow developers to add Scala Exercises-like abilities to their documentations. Basically it will traverse the DOM of any site which includes the generated JS script, decorate any Scala code block by adding an "evaluate" button (which will send requests to our Scala remote evaluator) and also allow live code edition and evaluation.

Right now the plugin just decorates the code with a button to allow calls to the remote evaluator, sending basic requests to the remote evaluator. Refactoring of the network code is also needed, as now it's using JQuery simple Ajax calls. Plans to integrate the remote evaluator client are in motion!

This PR is partly dependant on https://github.com/scala-exercises/evaluator/pull/31, which allows the Scala evaluator to receive CORS calls (like the ones produced by the plugin).

Could you please review @raulraja @juanpedromoreno @dialelo? Thanks!!