### PR TITLE
add hammock as a user of sbt-microsites

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Many Scala projects use sbt-microsites to display documentation and project note
 ![Scalding](https://twitter.github.io/scalding/img/navbar_brand.png) | [**Scalding**](https://twitter.github.io/scalding/) | Scala API for Hadoop and Cascading
 ![fetch](https://47deg.github.io/fetch/img/navbar_brand.png) | [**fetch**](https://47deg.github.io/fetch/) | Simple & Efficient data access for Scala and Scala.js
 ![github4s](https://47deg.github.io/github4s/img/navbar_brand.png) | [**github4s**](https://47deg.github.io/github4s/) | A GitHub API wrapper written in Scala
+![hammock](https://pepegar.github.io/hammock/img/navbar_brand.png) | [**hammock**](https://pepegar.github.io/hammock/) | A purely functional HTTP client for Scala


### PR DESCRIPTION
Adds [hammock](http://pepegar.github.io/hammock) to the _sbt-microsites in the wild_ section.