### PR TITLE
Remove logo inline styles

### DIFF
--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -80,7 +80,7 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
     ul(id := "sidebar", cls := "sidebar-nav",
       li(cls := "sidebar-brand",
         a(href := "{{ site.baseurl }}/", cls := "brand",
-          div(cls := "brand-wrapper", style := "background:url('{{site.baseurl}}/img/sidebar_brand.png') no-repeat", span(config.identity.name))
+          div(cls := "brand-wrapper", span(config.identity.name))
         )
       ),
       "{% if site.data.menu.options %}",

--- a/src/main/scala/microsites/layouts/PageLayout.scala
+++ b/src/main/scala/microsites/layouts/PageLayout.scala
@@ -55,7 +55,6 @@ class PageLayout(config: MicrositeSettings) extends Layout(config) {
                 a(href := "{{ site.baseurl }}/",
                   cls := "brand",
                   div(cls := "icon-wrapper",
-                      style := "background:url('{{site.baseurl}}/img/navbar_brand.png') no-repeat",
                       span(config.identity.name)))),
             buildCollapseMenu)),
       div(cls := "jumbotron",


### PR DESCRIPTION
Remove inline styles preventing logo on docs and page layouts from being rendered at 2x.
To see this in action, uncheck the `background` inline style for the logo on these pages:
- Example for docs layout: http://typelevel.org/cats/typeclasses.html
- Example for page layout: http://typelevel.org/cats/colophon.html

and see how they now render using the 2x version on a high DPI (retina) screen.