### PR TITLE
Including default includeFilter in sbt-microsites settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,8 +46,7 @@ lazy val micrositeSettings = Seq(
   micrositeDocumentationUrl := "/sbt-microsites/docs/",
   micrositeGithubOwner := "47deg",
   micrositeGithubRepo := "sbt-microsites",
-  micrositeHighlightTheme := "color-brewer",
-  includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.md"
+  micrositeHighlightTheme := "color-brewer"
 )
 
 lazy val buildInfoSettings = Seq(

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -82,7 +82,8 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGithubOwner := "47deg",
     micrositeGithubRepo := "sbt-microsites",
     micrositeGitHostingService := GitHub,
-    micrositeGitHostingUrl := "")
+    micrositeGitHostingUrl := "",
+    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico"))
 
   lazy val micrositeHelper: Def.Initialize[MicrositeHelper] = Def.setting {
     val baseUrl =


### PR DESCRIPTION
Fixes: #134 

This PR fixes a bug that prevented non-PNG image resources to be used in microsites. `sbt-site` uses a filter setting to copy those files, but until now it wasn't being used correctly. The right configuration will be now applied by default, and will include the most common image file extensions.

Could you please review, @juanpedromoreno? Thanks!