### PR TITLE
Autogenerate favicons from the navbar_brand file as a default option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,11 +30,12 @@ lazy val pluginSettings = Seq(
       "jgit-repo" at "http://download.eclipse.org/jgit/maven"
     ),
     libraryDependencies ++= Seq(
-      "com.lihaoyi"    %% "scalatags"    % "0.6.0",
-      "org.scalactic"  %% "scalactic"    % "3.0.0",
-      "net.jcazevedo"  %% "moultingyaml" % "0.4.0",
-      "org.scalatest"  %% "scalatest"    % versions("scalatest") % "test",
-      "org.scalacheck" %% "scalacheck"   % versions("scalacheck") % "test"
+      "com.lihaoyi"           %% "scalatags"     % "0.6.0",
+      "org.scalactic"         %% "scalactic"     % "3.0.0",
+      "net.jcazevedo"         %% "moultingyaml"  % "0.4.0",
+      "com.sksamuel.scrimage" %% "scrimage-core" % "2.1.7",
+      "org.scalatest"         %% "scalatest"     % versions("scalatest") % "test",
+      "org.scalacheck"        %% "scalacheck"    % versions("scalacheck") % "test"
     ),
     scalafmtConfig in ThisBuild := Some(file(".scalafmt"))
   ) ++ reformatOnCompileSettings

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -185,6 +185,11 @@ micrositePalette := Map(
         "gray-lighter"      -> "#F4F3F4",
         "white-color"       -> "#FFFFFF")
 ```
+- `micrositeFavicons`: list of filenames and sizes for the PNG/ICO files to be used as favicons for the generated site, located in the default image directory. The sizes should be described with a string (i.e.: \"16x16\"). If not provided, favicons with different sizes will be generated from the navbar_brand2x.jpg file.
+
+```
+micrositeFavicons := Seq(MicrositeFavicon("favicon16x16.png", "16x16"), MicrositeFavicon("favicon32x32.png", "32x32"))
+```
 
 - `micrositeConfigYaml`: this setting brings the capability to customize the Jekyll `_config.yml` file in three different ways (not exclusive to each other):
 

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -48,31 +48,31 @@ trait MicrositeKeys {
   val micrositeDocumentationUrl = settingKey[String]("Microsite site documentation url")
   val micrositeHighlightTheme   = settingKey[String]("Microsite Highlight Theme")
   val micrositeConfigYaml       = settingKey[ConfigYml]("Microsite _config.yml file configuration.")
-  val micrositeImgDirectory     = settingKey[File](
+  val micrositeImgDirectory = settingKey[File](
     "Optional. Microsite images directory. By default, it'll be the resourcesDirectory + '/microsite/img'")
-  val micrositeCssDirectory     = settingKey[File](
+  val micrositeCssDirectory = settingKey[File](
     "Optional. Microsite CSS directory. By default, it'll be the resourcesDirectory + '/microsite/css'")
-  val micrositeJsDirectory      = settingKey[File](
+  val micrositeJsDirectory = settingKey[File](
     "Optional. Microsite Javascript directory. By default, it'll be the resourcesDirectory + '/microsite/js'")
-  val micrositeCDNDirectives    = settingKey[CdnDirectives](
+  val micrositeCDNDirectives = settingKey[CdnDirectives](
     "Optional. Microsite CDN directives lists (for css and js imports). By default, both lists are empty.")
   val micrositeExternalLayoutsDirectory = settingKey[File](
     "Optional. Microsite external layouts directory. By default, it'll be the resourcesDirectory + '/microsite/layout'")
   val micrositeExternalIncludesDirectory = settingKey[File](
     "Optional. Microsite external includes (partial layouts) directory. By default, it'll be the resourcesDirectory + '/microsite/includes'")
-  val micrositeDataDirectory    = settingKey[File](
+  val micrositeDataDirectory = settingKey[File](
     "Optional. Microsite Data directory, useful to define the microsite data files " +
       "(https://jekyllrb.com/docs/datafiles/). By default, it'll be the resourcesDirectory + '/microsite/data'")
-  val micrositeExtraMdFiles     = settingKey[Map[File, ExtraMdFileConfig]](
+  val micrositeExtraMdFiles = settingKey[Map[File, ExtraMdFileConfig]](
     "Optional. This key is useful when you want to include automatically markdown documents as a part of your microsite, and these files are located in different places from the tutSourceDirectory. The map key is related with the source file, the map value corresponds with the target relative file path and the document meta-information configuration. By default, the map is empty.")
-  val micrositePalette          = settingKey[Map[String, String]]("Microsite palette")
-  val micrositeFaviconFilename  = settingKey[Option[String]](
-    "Optional. Filename for the PNG/ICO file to be used as favicon for the generated site, located in '/microsite/img'. By default it won't be provided.")
-  val micrositeGithubOwner      = settingKey[String]("Microsite Github owner")
-  val micrositeGithubRepo       = settingKey[String]("Microsite Github repo")
+  val micrositePalette = settingKey[Map[String, String]]("Microsite palette")
+  val micrositeFavicons = settingKey[Seq[MicrositeFavicon]](
+    "Optional. Filename and size for the PNG/ICO file to be used as favicon for the generated site, located in '/microsite/img'. The size should be described with a string (i.e.: \"16x16\"). By default, favicons with different sizes will be generated from the navbar_brand2x.jpg file.")
+  val micrositeGithubOwner = settingKey[String]("Microsite Github owner")
+  val micrositeGithubRepo  = settingKey[String]("Microsite Github repo")
   val micrositeGitHostingService =
     settingKey[GitHostingService]("Service used for git hosting. By default, it'll be GitHub.")
-  val micrositeGitHostingUrl    = settingKey[String](
+  val micrositeGitHostingUrl = settingKey[String](
     "In the case where your project isn't hosted on Github, use this setting to point users to git host (e.g. 'https://internal.gitlab.com/<user>/<project>').")
 }
 object MicrositeKeys extends MicrositeKeys

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -67,7 +67,7 @@ trait MicrositeKeys {
     "Optional. This key is useful when you want to include automatically markdown documents as a part of your microsite, and these files are located in different places from the tutSourceDirectory. The map key is related with the source file, the map value corresponds with the target relative file path and the document meta-information configuration. By default, the map is empty.")
   val micrositePalette = settingKey[Map[String, String]]("Microsite palette")
   val micrositeFavicons = settingKey[Seq[MicrositeFavicon]](
-    "Optional. Filename and size for the PNG/ICO file to be used as favicon for the generated site, located in '/microsite/img'. The size should be described with a string (i.e.: \"16x16\"). By default, favicons with different sizes will be generated from the navbar_brand2x.jpg file.")
+    "Optional. List of filenames and sizes for the PNG/ICO files to be used as favicon for the generated site, located in '/microsite/img'. The sizes should be described with a string (i.e.: \"16x16\"). By default, favicons with different sizes will be generated from the navbar_brand2x.jpg file.")
   val micrositeGithubOwner = settingKey[String]("Microsite Github owner")
   val micrositeGithubRepo  = settingKey[String]("Microsite Github repo")
   val micrositeGitHostingService =

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -78,7 +78,7 @@ object MicrositesPlugin extends AutoPlugin {
                             "gray-light"      -> "#E3E2E3",
                             "gray-lighter"    -> "#F4F3F4",
                             "white-color"     -> "#FFFFFF"),
-    micrositeFaviconFilename := None,
+    micrositeFavicons := Seq(),
     micrositeGithubOwner := "47deg",
     micrositeGithubRepo := "sbt-microsites",
     micrositeGitHostingService := GitHub,
@@ -119,7 +119,7 @@ object MicrositesPlugin extends AutoPlugin {
         visualSettings = MicrositeVisualSettings(
           highlightTheme = micrositeHighlightTheme.value,
           palette = micrositePalette.value,
-          faviconFilename = micrositeFaviconFilename.value
+          favicons = micrositeFavicons.value
         ),
         configYaml = configWithAllCustomVariables,
         fileLocations = MicrositeFileLocations(

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -18,47 +18,56 @@ package microsites.layouts
 
 import microsites.MicrositeSettings
 import microsites.util.FileHelper._
+import microsites.util.MicrositeHelper
 
 import scalatags.Text.TypedTag
 import scalatags.Text.all._
-import scalatags.Text.tags2.{title, nav}
+import scalatags.Text.tags2.{nav, title}
 
 abstract class Layout(config: MicrositeSettings) {
   implicitly(config)
+
+  lazy val micrositeHelper = new MicrositeHelper(config)
 
   def render: TypedTag[String]
 
   def commonHead: TypedTag[String] = {
     head(
       metas,
+      favicons,
       styles
     )
   }
 
   def metas: List[TypedTag[String]] =
-    List(
-      meta(charset := "utf-8"),
-      meta(httpEquiv := "X-UA-Compatible", content := "IE=edge,chrome=1"),
-      title(config.identity.name),
-      meta(name := "viewport", content := "width=device-width, initial-scale=1.0"),
-      meta(name := "description", content := config.identity.description),
-      meta(name := "author", content := config.identity.author),
-      meta(name := "og:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
-      meta(name := "og:title", content := config.identity.name),
-      meta(name := "og:site_name", content := config.identity.name),
-      meta(name := "og:url", content := config.identity.homepage),
-      meta(name := "og:type", content := "website"),
-      meta(name := "og:description", content := config.identity.description),
-      meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
-      meta(name := "twitter:card", content := "summary_large_image"),
-      meta(name := "twitter:site", content := config.identity.twitter)) ++ config.visualSettings.faviconFilename
-      .map(
-        icon =>
-          List(
-            link(rel := "icon",
-                 `type` := "image/png",
-                 href := s"{{site.url}}{{site.baseurl}}/img/$icon")))
-      .getOrElse(List())
+    List(meta(charset := "utf-8"),
+         meta(httpEquiv := "X-UA-Compatible", content := "IE=edge,chrome=1"),
+         title(config.identity.name),
+         meta(name := "viewport", content := "width=device-width, initial-scale=1.0"),
+         meta(name := "description", content := config.identity.description),
+         meta(name := "author", content := config.identity.author),
+         meta(name := "og:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+         meta(name := "og:title", content := config.identity.name),
+         meta(name := "og:site_name", content := config.identity.name),
+         meta(name := "og:url", content := config.identity.homepage),
+         meta(name := "og:type", content := "website"),
+         meta(name := "og:description", content := config.identity.description),
+         meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+         meta(name := "twitter:card", content := "summary_large_image"),
+         meta(name := "twitter:site", content := config.identity.twitter))
+
+  def favicons: List[TypedTag[String]] =
+    (if (config.visualSettings.favicons.nonEmpty) {
+       config.visualSettings.favicons
+     } else {
+       micrositeHelper.faviconDescriptions
+     }).map {
+      case icon =>
+        link(rel := "icon",
+             `type` := "image/png",
+             attr("sizes") := s"${icon.sizeDescription}",
+             href := s"{{site.url}}{{site.baseurl}}/img/${icon.filename}")
+    }.toList
 
   def styles: List[TypedTag[String]] = {
 

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -43,9 +43,11 @@ package object microsites {
 
   case class MicrositeUrlSettings(micrositeBaseUrl: String, micrositeDocumentationUrl: String)
 
+  case class MicrositeFavicon(filename: String, sizeDescription: String)
+
   case class MicrositeVisualSettings(highlightTheme: String,
                                      palette: Map[String, String],
-                                     faviconFilename: Option[String])
+                                     favicons: Seq[MicrositeFavicon])
 
   case class MicrositeSettings(identity: MicrositeIdentitySettings,
                                visualSettings: MicrositeVisualSettings,

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -32,27 +32,12 @@ class MicrositeHelper(config: MicrositeSettings) {
   implicitly(config)
 
   val jekyllDir = "jekyll"
-  val faviconSizes = Seq(16,
-                         24,
-                         32,
-                         48,
-                         57,
-                         60,
-                         64,
-                         70,
-                         72,
-                         76,
-                         96,
-                         114,
-                         120,
-                         128,
-                         144,
-                         150,
-                         152,
-                         196,
-                         310).map { w =>
-    (w, w)
-  } ++ Seq((310, 150))
+
+  // format: OFF
+  val faviconHeights = Seq(16, 24, 32, 48, 57, 60, 64, 70, 72, 76, 96,
+                           114, 120, 128, 144, 150, 152, 196, 310)
+  val faviconSizes = (faviconHeights zip faviconHeights) ++ Seq((310, 150))
+  // format: ON
 
   lazy val faviconFilenames = faviconSizes.foldLeft(Seq[String]())((list, size) => {
     val (width, height) = size

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -26,11 +26,43 @@ import microsites.util.FileHelper._
 import sbt._
 
 import scala.io.Source
+import com.sksamuel.scrimage._
 
 class MicrositeHelper(config: MicrositeSettings) {
   implicitly(config)
 
   val jekyllDir = "jekyll"
+  val faviconSizes = Seq(16,
+                         24,
+                         32,
+                         48,
+                         57,
+                         60,
+                         64,
+                         70,
+                         72,
+                         76,
+                         96,
+                         114,
+                         120,
+                         128,
+                         144,
+                         150,
+                         152,
+                         196,
+                         310).map { w =>
+    (w, w)
+  } ++ Seq((310, 150))
+
+  lazy val faviconFilenames = faviconSizes.foldLeft(Seq[String]())((list, size) => {
+    val (width, height) = size
+    list :+ s"favicon${width}x${height}.png"
+  })
+
+  lazy val faviconDescriptions = (faviconFilenames zip faviconSizes).map {
+    case (filename, (width, height)) =>
+      MicrositeFavicon(filename, s"${width}x${height}")
+  }
 
   def createResources(resourceManagedDir: File, tutSourceDirectory: File): List[File] = {
 
@@ -75,7 +107,7 @@ class MicrositeHelper(config: MicrositeSettings) {
     }
 
     List(createConfigYML(targetDir), createPalette(targetDir)) ++
-      createLayouts(targetDir) ++ createPartialLayout(targetDir)
+      createLayouts(targetDir) ++ createPartialLayout(targetDir) ++ createFavicons(targetDir)
   }
 
   def createConfigYML(targetDir: String): File = {
@@ -128,6 +160,18 @@ class MicrositeHelper(config: MicrositeSettings) {
         IO.write(targetFile, layout.render.toString())
         targetFile
     }
+
+  def createFavicons(targetDir: String): List[File] = {
+    val sourceFile = createFilePathIfNotExists(s"$targetDir$jekyllDir/img/navbar_brand2x.png")
+
+    (faviconFilenames zip faviconSizes).map {
+      case (name, size) =>
+        (new File(s"$targetDir$jekyllDir/img/$name"), size)
+    }.map {
+      case (file, (width, height)) =>
+        Image.fromFile(sourceFile).scaleTo(width, height).output(file)
+    }.toList
+  }
 
   def copyConfigurationFile(sourceDir: File, targetDir: File): Unit = {
 

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -75,6 +75,13 @@ trait Arbitraries {
     )
   }
 
+  implicit def micrositeFaviconArbitrary: Arbitrary[MicrositeFavicon] = Arbitrary {
+    for {
+      filename <- Arbitrary.arbitrary[String]
+      size     <- Arbitrary.arbitrary[String]
+    } yield MicrositeFavicon(filename, size)
+  }
+
   implicit def settingsArbitrary: Arbitrary[MicrositeSettings] = Arbitrary {
     for {
       name                               ← Arbitrary.arbitrary[String]
@@ -95,7 +102,7 @@ trait Arbitraries {
       micrositeBaseUrl                   ← Arbitrary.arbitrary[String]
       micrositeDocumentationUrl          ← Arbitrary.arbitrary[String]
       palette                            ← paletteMapArbitrary.arbitrary
-      favicon                            ← Arbitrary.arbitrary[Option[String]]
+      favicon                            ← listOf[MicrositeFavicon](micrositeFaviconArbitrary.arbitrary)
       githubOwner                        ← Arbitrary.arbitrary[String]
       githubRepo                         ← Arbitrary.arbitrary[String]
       gitHostingService                  ← Arbitrary.arbitrary[GitHostingService]


### PR DESCRIPTION
Fixes: #136 

This PR adds a default option for the favicon setting in the `sbt-microsites`, that creates a set of favicons from the `navbar_brand2x.jpg` file (offering different sizes for different devices) and links them to our different layouts.

Could you please review, @juanpedromoreno? Thanks!!