### PR TITLE
Adding CNAME as default includeFilter in Jekyll

### DIFF
--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -89,7 +89,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeKazariResolvers := Seq(),
     micrositeGitHostingService := GitHub,
     micrositeGitHostingUrl := "",
-    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico"))
+    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME"))
 
   lazy val micrositeHelper: Def.Initialize[MicrositeHelper] = Def.setting {
     val baseUrl =


### PR DESCRIPTION
This PR adds CNAME files to the default includeFilters for the sbt-microsites settings. Could you please review, @raulraja @juanpedromoreno? Thanks!