### PR TITLE
Add Scala Version to KazariDependency

### DIFF
--- a/KAZARI_README.md
+++ b/KAZARI_README.md
@@ -23,8 +23,10 @@ Once you have added these CSS classes to your code, just build your microsite as
 * **micrositeKazariEvaluatorToken**: remote Scala Evaluator token to be used by Kazari. Check out the [README of the evaluator](https://github.com/scala-exercises/evaluator) for information on how to generate it.
 * **micrositeKazariGithubToken**: optional GitHub token to be used by Kazari. Required for Kazari to perform certain actions (i.e. save Gists), which are still experimental.
 * **micrositeKazariCodeMirrorTheme**: optional CodeMirror theme to be used by Kazari in its modal editor.
-* **micrositeKazariDependencies**: optional list of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion, onlyPrefix and versionId).
+* **micrositeKazariDependencies**: optional list of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion and versionId).
 * **micrositeKazariResolvers**: optional list of resolver urls needed for the provided dependencies to be fetched by Kazari.
+
+In case you need it to set up your `micrositeKazariDependencies`, a `buildWithoutSuffix(scalaVersion: String)` is provided by `sbt-microsites` just importing `microsites.util.BuildHelper._`. You can use the default implementation provided or override it creating your own.
 
 Kazari will try to match its color scheme to the Microsite's highlight color theme. If the default colors don't quite match or you want to change them, we provide a few class for you to customize:
 

--- a/KAZARI_README.md
+++ b/KAZARI_README.md
@@ -23,7 +23,7 @@ Once you have added these CSS classes to your code, just build your microsite as
 * **micrositeKazariEvaluatorToken**: remote Scala Evaluator token to be used by Kazari. Check out the [README of the evaluator](https://github.com/scala-exercises/evaluator) for information on how to generate it.
 * **micrositeKazariGithubToken**: optional GitHub token to be used by Kazari. Required for Kazari to perform certain actions (i.e. save Gists), which are still experimental.
 * **micrositeKazariCodeMirrorTheme**: optional CodeMirror theme to be used by Kazari in its modal editor.
-* **micrositeKazariDependencies**: optional list of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, and versionId).
+* **micrositeKazariDependencies**: optional list of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion, onlyPrefix and versionId).
 * **micrositeKazariResolvers**: optional list of resolver urls needed for the provided dependencies to be fetched by Kazari.
 
 Kazari will try to match its color scheme to the Microsite's highlight color theme. If the default colors don't quite match or you want to change them, we provide a few class for you to customize:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Microsites comes with a range of options to customize and configure your project
 
 # Kazari plugin
 
-If you already have some pre-existing documentation for your project, `sbt-microsites` also provides a Javascript plugin called [Kazari](KAZARI_PLUGIN.md) that decorates your code snippets with functionality that allows users to edit them live and run them in a remote Scala evaluator; making the learning process a whole lot easier.
+If you already have some pre-existing documentation for your project, `sbt-microsites` also provides a Javascript plugin called [Kazari](KAZARI_README.md) that decorates your code snippets with functionality that allows users to edit them live and run them in a remote Scala evaluator; making the learning process a whole lot easier.
 
 # sbt-microsites in the wild
 

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -82,7 +82,7 @@ trait MicrositeKeys {
   val micrositeKazariCodeMirrorTheme = settingKey[String](
     "Optional. CodeMirror theme to be used by Kazari in its modal editor. Default: monokai")
   val micrositeKazariDependencies = settingKey[Seq[KazariDependency]](
-    "Optional. List of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, and versionId). Default: empty list")
+    "Optional. List of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion, onlyPrefix and versionId). Default: empty list")
   val micrositeKazariResolvers = settingKey[Seq[String]](
     "Optional. List of resolver urls needed for the provided dependencies to be fetched by Kazari. Default: empty list")
   val micrositeGitHostingService =

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -82,7 +82,7 @@ trait MicrositeKeys {
   val micrositeKazariCodeMirrorTheme = settingKey[String](
     "Optional. CodeMirror theme to be used by Kazari in its modal editor. Default: monokai")
   val micrositeKazariDependencies = settingKey[Seq[KazariDependency]](
-    "Optional. List of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion, onlyPrefix and versionId). Default: empty list")
+    "Optional. List of dependencies needed to compile the code to be evaluated by Kazari (set of groupId, artifactId, scalaVersion and versionId). Default: empty list")
   val micrositeKazariResolvers = settingKey[Seq[String]](
     "Optional. List of resolver urls needed for the provided dependencies to be fetched by Kazari. Default: empty list")
   val micrositeGitHostingService =

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -40,33 +40,44 @@ abstract class Layout(config: MicrositeSettings) {
   }
 
   def metas: List[TypedTag[String]] =
-    List(meta(charset := "utf-8"),
-         meta(httpEquiv := "X-UA-Compatible", content := "IE=edge,chrome=1"),
-         title(config.identity.name),
-         meta(name := "viewport", content := "width=device-width, initial-scale=1.0"),
-         meta(name := "description", content := config.identity.description),
-         meta(name := "author", content := config.identity.author),
-         meta(name := "og:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
-         meta(name := "og:title", content := config.identity.name),
-         meta(name := "og:site_name", content := config.identity.name),
-         meta(name := "og:url", content := config.identity.homepage),
-         meta(name := "og:type", content := "website"),
-         meta(name := "og:description", content := config.identity.description),
-         meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
-         meta(name := "twitter:card", content := "summary_large_image"),
-         meta(name := "twitter:site", content := config.identity.twitter),
-         meta(name := "kazari-dependencies",
-              content :=
-                config.micrositeKazariSettings.micrositeKazariDependencies
-                  .map(dependency =>
-                    s"${dependency.groupId};${dependency.artifactId};${dependency.version}")
-                  .mkString(",")),
-         meta(name := "kazari-resolvers",
-              content :=
-                config.micrositeKazariSettings.micrositeKazariResolvers.mkString(",")),
-         link(rel := "icon",
-              `type` := "image/png",
-              href := "{{site.url}}{{site.baseurl}}/img/favicon.png"))
+    List(
+      meta(charset := "utf-8"),
+      meta(httpEquiv := "X-UA-Compatible", content := "IE=edge,chrome=1"),
+      title(config.identity.name),
+      meta(name := "viewport", content := "width=device-width, initial-scale=1.0"),
+      meta(name := "description", content := config.identity.description),
+      meta(name := "author", content := config.identity.author),
+      meta(name := "og:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+      meta(name := "og:title", content := config.identity.name),
+      meta(name := "og:site_name", content := config.identity.name),
+      meta(name := "og:url", content := config.identity.homepage),
+      meta(name := "og:type", content := "website"),
+      meta(name := "og:description", content := config.identity.description),
+      meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+      meta(name := "twitter:card", content := "summary_large_image"),
+      meta(name := "twitter:site", content := config.identity.twitter),
+      meta(
+        name := "kazari-dependencies",
+        content :=
+          config.micrositeKazariSettings.micrositeKazariDependencies
+            .map(dependency => {
+              val scalaVersion =
+                if (dependency.onlyPrefix) {
+                  dependency.scalaVersion match {
+                    case sv if sv.startsWith("2.12") => "2.12"
+                    case sv if sv.startsWith("2.11") => "2.11"
+                    case sv                          => sv
+                  }
+                } else dependency.scalaVersion
+              s"${dependency.groupId};${dependency.artifactId}_$scalaVersion;${dependency.version}"
+            })
+            .mkString(",")),
+      meta(name := "kazari-resolvers",
+           content :=
+             config.micrositeKazariSettings.micrositeKazariResolvers.mkString(",")),
+      link(rel := "icon",
+           `type` := "image/png",
+           href := "{{site.url}}{{site.baseurl}}/img/favicon.png"))
 
   def favicons: List[TypedTag[String]] =
     (if (config.visualSettings.favicons.nonEmpty) {

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -60,17 +60,8 @@ abstract class Layout(config: MicrositeSettings) {
         name := "kazari-dependencies",
         content :=
           config.micrositeKazariSettings.micrositeKazariDependencies
-            .map(dependency => {
-              val scalaVersion =
-                if (dependency.onlyPrefix) {
-                  dependency.scalaVersion match {
-                    case sv if sv.startsWith("2.12") => "2.12"
-                    case sv if sv.startsWith("2.11") => "2.11"
-                    case sv                          => sv
-                  }
-                } else dependency.scalaVersion
-              s"${dependency.groupId};${dependency.artifactId}_$scalaVersion;${dependency.version}"
-            })
+            .map(dependency =>
+              s"${dependency.groupId};${dependency.artifactId}_${dependency.scalaVersion};${dependency.version}")
             .mkString(",")),
       meta(name := "kazari-resolvers",
            content :=

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -21,7 +21,11 @@ import scala.language.{postfixOps, reflectiveCalls}
 
 package object microsites {
 
-  case class KazariDependency(groupId: String, artifactId: String, version: String)
+  case class KazariDependency(groupId: String,
+                              artifactId: String,
+                              scalaVersion: String,
+                              onlyPrefix: Boolean,
+                              version: String)
 
   case class KazariSettings(micrositeKazariEvaluatorUrl: String,
                             micrositeKazariEvaluatorToken: String,

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -24,7 +24,6 @@ package object microsites {
   case class KazariDependency(groupId: String,
                               artifactId: String,
                               scalaVersion: String,
-                              onlyPrefix: Boolean,
                               version: String)
 
   case class KazariSettings(micrositeKazariEvaluatorUrl: String,

--- a/src/main/scala/microsites/util/BuildHelper.scala
+++ b/src/main/scala/microsites/util/BuildHelper.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package microsites.util
+
+trait BuildHelper {
+
+  def buildWithoutSuffix(scalaVersion: String): String =
+    scalaVersion match {
+      case scalaV if scalaV.startsWith("2.12") => "2.12"
+      case scalaV if scalaV.startsWith("2.11") => "2.11"
+      case scalaV                              => scalaV
+    }
+
+}
+
+object BuildHelper extends BuildHelper

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -18,10 +18,11 @@ package microsites.util
 
 import java.io.File
 
-import microsites._
 import microsites.MicrositeKeys._
+import microsites._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
+import sbt.Resolver
 
 trait Arbitraries {
 
@@ -70,10 +71,12 @@ trait Arbitraries {
 
   implicit def dependencyArbitrary: Arbitrary[KazariDependency] = Arbitrary {
     for {
-      dependencyGroup    ← Arbitrary.arbitrary[String]
-      dependencyArtifact ← Arbitrary.arbitrary[String]
-      dependencyVersion  ← Arbitrary.arbitrary[String]
-    } yield KazariDependency(dependencyGroup, dependencyArtifact, dependencyVersion)
+      dependencyGroup         ← Arbitrary.arbitrary[String]
+      dependencyArtifact      ← Arbitrary.arbitrary[String]
+      dependencyScalaVersion  ← Arbitrary.arbitrary[String]
+      dependencyOnlyPrefix    ← Arbitrary.arbitrary[Boolean]
+      dependencyVersion       ← Arbitrary.arbitrary[String]
+    } yield KazariDependency(dependencyGroup, dependencyArtifact, dependencyScalaVersion, dependencyOnlyPrefix, dependencyVersion)
   }
 
   implicit def dependenciesListArbitrary: Arbitrary[Seq[KazariDependency]] = Arbitrary {

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -74,9 +74,8 @@ trait Arbitraries {
       dependencyGroup         ← Arbitrary.arbitrary[String]
       dependencyArtifact      ← Arbitrary.arbitrary[String]
       dependencyScalaVersion  ← Arbitrary.arbitrary[String]
-      dependencyOnlyPrefix    ← Arbitrary.arbitrary[Boolean]
       dependencyVersion       ← Arbitrary.arbitrary[String]
-    } yield KazariDependency(dependencyGroup, dependencyArtifact, dependencyScalaVersion, dependencyOnlyPrefix, dependencyVersion)
+    } yield KazariDependency(dependencyGroup, dependencyArtifact, dependencyScalaVersion, dependencyVersion)
   }
 
   implicit def dependenciesListArbitrary: Arbitrary[Seq[KazariDependency]] = Arbitrary {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.0-SNAPSHOT"
+version in ThisBuild := "0.6.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR is related with issue #144 (currently, there is no need to send the compiler flags) and allows Kazari to include the right dependencies depending on the Scala version and the artefactId. 

It also increments the Kazari version to `0.6.0-SNAPSHOT`

@raulraja could you please review?

Thanks!