### PR TITLE
Use GitHub api to publish ghpages

### DIFF
--- a/docs/src/main/tut/docs/build-the-microsite.md
+++ b/docs/src/main/tut/docs/build-the-microsite.md
@@ -25,10 +25,15 @@ If you're running the microsite locally, you can follow these steps:
 
 # Publish the microsite
 
+From version "0.5.4", you have two options for publishing the site:
+ * sbt-ghpages: This is the default method. It uses the sbt-git and the local ssh keys for pushing the changes.
+ * github4s: Avoids using local ssh keys and publish the site with the web API. By contrast, you need to specify a token.
+
 Before publishing, a couple of requirements should be satisfied:
 
 1. Initializing the **gh-pages** branch, you can follow the instructions defined in the [sbt-ghpages](https://goo.gl/G0Ffv0) repository.
-2. Define `micrositeGithubOwner` and `micrositeGithubRepo` settings. You can see more details regarding this in the [Configuring the Microsite](settings.html) section.
+2. Define `micrositeGithubOwner` and `micrositeGithubRepo` settings and maybe the `micrositePushSiteWith` and `micrositeGithubRepo` settings.
+You can see more details regarding this in the [Configuring the Microsite](settings.html) section.
 
 Once both requirements are satisfied, you can just run:
 
@@ -36,7 +41,9 @@ Once both requirements are satisfied, you can just run:
 sbt> publishMicrosite
 ```
 
-And that's all. Behind the scenes, `makeMicrosite` and `pushSite` are invoked. The second task is possible thanks to [`sbt-ghpages` plugin](https://github.com/sbt/sbt-ghpages).
+And that's all. Behind the scenes, `makeMicrosite` and `pushSite` are invoked. 
+
+By default, the second task uses the [`sbt-ghpages` plugin](https://github.com/sbt/sbt-ghpages).
 
 If you don't have any domain names pointing to your site, you can see your microsite at:
 

--- a/docs/src/main/tut/docs/build-the-microsite.md
+++ b/docs/src/main/tut/docs/build-the-microsite.md
@@ -25,13 +25,13 @@ If you're running the microsite locally, you can follow these steps:
 
 # Publish the microsite
 
-From version "0.5.4", you have two options for publishing the site:
- * sbt-ghpages: This is the default method. It uses the sbt-git and the local ssh keys for pushing the changes.
- * github4s: Avoids using local ssh keys and publish the site with the web API. By contrast, you need to specify a token.
+From version [`0.5.4`](https://github.com/47deg/sbt-microsites/releases/tag/v0.5.4), you have two options for publishing the site:
+ * **sbt-ghpages**: This is the default method. It uses the sbt-git plugin and the local ssh keys for pushing the changes.
+ * **github4s**: Avoids using local ssh keys, publishing the site with the GitHub web API. By contrast, you need to specify a token.
 
 Before publishing, a couple of requirements should be satisfied:
 
-1. Initializing the **gh-pages** branch, you can follow the instructions defined in the [sbt-ghpages](https://goo.gl/G0Ffv0) repository.
+1. Initialize the **gh-pages** branch, you can follow the instructions defined in the [sbt-ghpages](https://goo.gl/G0Ffv0) repository.
 2. Define `micrositeGithubOwner` and `micrositeGithubRepo` settings and maybe the `micrositePushSiteWith` and `micrositeGithubRepo` settings.
 You can see more details regarding this in the [Configuring the Microsite](settings.html) section.
 

--- a/docs/src/main/tut/docs/build-the-microsite.md
+++ b/docs/src/main/tut/docs/build-the-microsite.md
@@ -25,9 +25,9 @@ If you're running the microsite locally, you can follow these steps:
 
 # Publish the microsite
 
-From version [`0.5.4`](https://github.com/47deg/sbt-microsites/releases/tag/v0.5.4), you have two options for publishing the site:
+From version [`0.5.4`](https://github.com/47deg/sbt-microsites/releases/tag/v0.5.4), you have two options to publish the site:
  * **sbt-ghpages**: This is the default method. It uses the sbt-git plugin and the local ssh keys for pushing the changes.
- * **github4s**: Avoids using local ssh keys, publishing the site with the GitHub web API. By contrast, you need to specify a token.
+ * **github4s**: Avoids using local ssh keys, publishing the site through the GitHub HTTP API and [Github4s](https://github.com/47deg/github4s). By contrast, you need to specify a token.
 
 Before publishing, a couple of requirements should be satisfied:
 

--- a/docs/src/main/tut/docs/publish-with-travis.md
+++ b/docs/src/main/tut/docs/publish-with-travis.md
@@ -148,11 +148,11 @@ With this method, you don't need to generate any ssh keys or encrypt any files. 
 
 You need to create a GitHub token with `repo` scope. You can create it in the [GitHub settings](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) page.
 
-Copy the token in a safe place, we'll send the token through an environment variable.
+Copy the token in a safe place, we'll use this token through an environment variable as we'll see shortly.
 
 **2- Configure your project build**
 
-You need to set these two properties:
+You need to set these two sbt settings:
 
 ```
 micrositePushSiteWith := GitHub4s

--- a/docs/src/main/tut/docs/publish-with-travis.md
+++ b/docs/src/main/tut/docs/publish-with-travis.md
@@ -5,7 +5,13 @@ title: Publish with Travis
 
 # Publish with Travis
 
-In this section, we’re going to learn how to configure Travis so you can publish your microsite when you merge in master. You can follow these steps:
+In this section, we’re going to learn how to configure Travis so you can publish your microsite when you merge in master.
+
+There are two options for publishing the site. See [Configuring the Microsite](settings.html) section for more information.
+
+## Publish using sbt-ghpages
+
+This is the used method when the property `micrositePushSiteWith` is set to `GHPagesPlugin`. The steps are:
 
 **1- Generate an SSH key pair**
 
@@ -133,3 +139,29 @@ sbt docs/publishMicrosite
 ```
 
 In this script, we are publishing the microsite in GitHub Pages. To do this, we should add the user information for git.
+
+## Publish using GitHub4s
+
+With this method, we don't need to generate any ssh keys or encrypt any files. We'll use the GitHub API for publishing the site. The steps are:
+
+**1- Create a token for your project**
+
+You need to create a GitHub token with `repo` scope. You can create it in the [GitHub settings](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites).
+
+Copy the token in a safe place, we'll send the token through an environment variable.
+
+**2- Configure your build**
+
+You need to set these properties:
+
+```
+micrositePushSiteWith := GitHub4s
+```
+
+```
+micrositeGithubToken := getEnvVar("GITHUB_TOKEN")
+```
+
+**3- Add the environment variable in Travis**
+
+The final step is to define the `GITHUB_TOKEN` environment variable in Travis Repository Settings. You can do it following [the documentation](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).

--- a/docs/src/main/tut/docs/publish-with-travis.md
+++ b/docs/src/main/tut/docs/publish-with-travis.md
@@ -11,7 +11,7 @@ There are two options for publishing the site. See [Configuring the Microsite](s
 
 ## Publish using sbt-ghpages
 
-This is the used method when the property `micrositePushSiteWith` is set to `GHPagesPlugin`. The steps are:
+When the property `micrositePushSiteWith` is set to `GHPagesPlugin` (by default), the site is pushed using the sbt-ghpages plugins. The steps for this approach are:
 
 **1- Generate an SSH key pair**
 
@@ -142,17 +142,17 @@ In this script, we are publishing the microsite in GitHub Pages. To do this, we 
 
 ## Publish using GitHub4s
 
-With this method, we don't need to generate any ssh keys or encrypt any files. We'll use the GitHub API for publishing the site. The steps are:
+With this method, you don't need to generate any ssh keys or encrypt any files. We'll use the GitHub API for publishing the site. The steps are:
 
 **1- Create a token for your project**
 
-You need to create a GitHub token with `repo` scope. You can create it in the [GitHub settings](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites).
+You need to create a GitHub token with `repo` scope. You can create it in the [GitHub settings](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) page.
 
 Copy the token in a safe place, we'll send the token through an environment variable.
 
-**2- Configure your build**
+**2- Configure your project build**
 
-You need to set these properties:
+You need to set these two properties:
 
 ```
 micrositePushSiteWith := GitHub4s

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -69,7 +69,7 @@ micrositeGithubOwner := "47deg"
 micrositeGithubRepo := "sbt-microsites"
 ```
 
-- `micrositeGithubToken`: used for publishing the site when `github4s` is enabled. A [token with repo scope](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) is needed. None by default:
+- `micrositeGithubToken`: used for publishing the site when `github4s` is enabled. A [token with repo scope](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) is needed. None by default, but you can override it in this way:
  
 ```
 micrositeGithubToken := getEnvVar("GITHUB_TOKEN")

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -62,11 +62,26 @@ micrositeAuthor := "47 Degrees"
 micrositeOrganizationHomepage := "http://www.47deg.com"
 ```
 
-- `micrositeGithubOwner` and `micrositeGithubRepo`: in order to add links to the `GitHub` repo, `micrositeGithubOwner` and `micrositeGithubRepo` are required:
+- `micrositeGithubOwner` and `micrositeGithubRepo`: in order to add links to the `GitHub` repo. It's also needed for publishing the site when `github4s` is chosen (see `micrositePushSiteWith` setting). Both, `micrositeGithubOwner` and `micrositeGithubRepo` are required:
 
 ```
 micrositeGithubOwner := "47deg"
 micrositeGithubRepo := "sbt-microsites"
+```
+
+- `micrositeGithubToken`: used for publishing the site when `github4s` is enabled. A [token with repo scope](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) is needed. None by default:
+ 
+```
+micrositeGithubToken := getEnvVar("GITHUB_TOKEN")
+```
+
+- `micrositePushSiteWith`: determines how the site will be pushed. It accept two values:
+
+* `GHPagesPlugin`: The default value. The plugin will use the `sbt-ghpages` plugin for publishing the site.
+* `GitHub4s`: The [GitHub4s](https://github.com/47deg/github4s) will be used for publishing the site. By now, only GitHub is supported. You need to specify a value for the `micrositeGithubToken` in order to use this publishing method.
+
+```
+micrositePushSiteWith := GitHub4s
 ```
 
 - `micrositeGitHostingService` and `micrositeGitHostingUrl`: in order to specify a hosting service other than `GitHub`:

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -37,3 +37,5 @@ Additionally, it depends on other useful libraries and plugins like:
 * [sbt-scalafmt](https://github.com/olafurpg/scalafmt)
 * [sbt-pgp](https://github.com/sbt/sbt-pgp)
 * [sbt-header](https://github.com/sbt/sbt-header)
+* [GitHub4s](https://github.com/47deg/github4s)
+* [sbt-org-policies](https://github.com/47deg/sbt-org-policies)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -26,7 +26,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.tpolecat"     % "tut-plugin"  % "0.4.8"),
       libraryDependencies ++= Seq(
         %%("moultingyaml"),
-        "com.47deg"             %% "org-policies-core" % "0.4.6",
+        "com.47deg"             %% "org-policies-core" % "0.4.13",
         "com.lihaoyi"           %% "scalatags" % "0.6.0",
         "org.scalactic"         %% "scalactic" % "3.0.0",
         "com.sksamuel.scrimage" %% "scrimage-core" % "2.1.7",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
-
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.6")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.13")

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -94,6 +94,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGitHostingService := GitHub,
     micrositeGitHostingUrl := "",
     micrositePushSiteWith := GHPagesPlugin,
-    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME")
+    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME"),
+    commands ++= Seq(micrositePushSiteCommand)
   )
 }

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -85,6 +85,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeFavicons := Seq(),
     micrositeGithubOwner := "47deg",
     micrositeGithubRepo := "sbt-microsites",
+    micrositeGithubToken := None,
     micrositeKazariEvaluatorUrl := "https://scala-evaluator-212.herokuapp.com",
     micrositeKazariEvaluatorToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.S2F6YXJp.Jl2eqMfw8IakJF93PjxTbrf-8YUJgX5OoOfy5JHE8Yw",
     micrositeKazariGithubToken := "",
@@ -95,6 +96,6 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGitHostingUrl := "",
     micrositePushSiteWith := GHPagesPlugin,
     includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME"),
-    commands ++= Seq(micrositePushSiteCommand)
+    commands ++= Seq(publishMicrositeCommand)
   )
 }

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -93,6 +93,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeKazariResolvers := Seq(),
     micrositeGitHostingService := GitHub,
     micrositeGitHostingUrl := "",
+    micrositePushSiteWith := GHPagesPlugin,
     includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME")
   )
 }

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -32,9 +32,9 @@ import scala.io.Source
 class MicrositeHelper(config: MicrositeSettings) {
   implicitly(config)
 
-  val fw = new FileWriter
+  import MicrositeHelper._
 
-  val jekyllDir = "jekyll"
+  val fw = new FileWriter
 
   // format: OFF
   val faviconHeights = List(16, 24, 32, 48, 57, 60, 64, 70, 72, 76, 96,
@@ -201,4 +201,10 @@ class MicrositeHelper(config: MicrositeSettings) {
       .map(parent => sourceDir.*** pair relativeTo(parent))
       .getOrElse(sourceDir.*** pair basic)
   }
+}
+
+object MicrositeHelper {
+
+  val jekyllDir = "jekyll"
+
 }

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -32,9 +32,9 @@ import scala.io.Source
 class MicrositeHelper(config: MicrositeSettings) {
   implicitly(config)
 
-  import MicrositeHelper._
-
   val fw = new FileWriter
+
+  val jekyllDir = "jekyll"
 
   // format: OFF
   val faviconHeights = List(16, 24, 32, 48, 57, 60, 64, 70, 72, 76, 96,
@@ -201,10 +201,4 @@ class MicrositeHelper(config: MicrositeSettings) {
       .map(parent => sourceDir.*** pair relativeTo(parent))
       .getOrElse(sourceDir.*** pair basic)
   }
-}
-
-object MicrositeHelper {
-
-  val jekyllDir = "jekyll"
-
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.4-SNAPSHOT"
+version in ThisBuild := "0.5.4"


### PR DESCRIPTION
This PR replaces the publishMicrosite task with a command. Now, depending of the `micrositePushSiteWith` setting value, the plugin will publish the site with sbt-ghpages or github4s API.

Please @juanpedromoreno, could you review? Thanks!
