### PR TITLE
Enriched version of `includeFilter`

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -28,7 +28,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.tpolecat"     % "tut-plugin"  % "0.5.2"),
       libraryDependencies ++= Seq(
         %%("moultingyaml"),
-        "com.47deg"             %% "org-policies-core" % "0.5.6",
+        "com.47deg"             %% "org-policies-core" % "0.5.8",
         "com.lihaoyi"           %% "scalatags" % "0.6.5",
         "org.scalactic"         %% "scalactic" % "3.0.3",
         "com.sksamuel.scrimage" %% "scrimage-core" % "2.1.7",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 resolvers ++= Seq(Resolver.sonatypeRepo("snapshots"), Resolver.sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.6")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.5.8")

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -19,6 +19,7 @@ package microsites
 import com.typesafe.sbt.SbtGit.git
 import com.typesafe.sbt.sbtghpages.GhpagesPlugin
 import com.typesafe.sbt.site.jekyll.JekyllPlugin
+import com.typesafe.sbt.site.SitePlugin.autoImport._
 import sbt.Keys._
 import sbt._
 import sbt.plugins.IvyPlugin
@@ -99,7 +100,8 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeAnalyticsToken := "",
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := s"${micrositeGithubOwner.value}/${micrositeGithubRepo.value}",
-    includeFilter in Jekyll := ("*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME"),
+    includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
+    includeFilter in Jekyll := (includeFilter in makeSite).value,
     commands ++= Seq(publishMicrositeCommand)
   )
 }


### PR DESCRIPTION
This PR provides an enriched version of `includeFilter` setting scoped to both `makeSite` and `Jekyll`, where we are adding the ability to copy source and resource files with extension `yml`, `json` and `svg`.