### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -79,11 +79,6 @@ object ProjectPlugin extends AutoPlugin {
       libraryDependencies ++= Seq(
         %%%("github4s"),
         %%%("roshttp"),
-        %%%("cats-free"),
-        %%%("circe-core"),
-        %%%("circe-generic"),
-        %%%("circe-parser"),
-        %%%("base64"),
         "org.scala-js"        %%% "scalajs-dom"       % "0.9.0",
         "be.doeraene"         %%% "scalajs-jquery"    % "0.9.0",
         "com.lihaoyi"         %%% "upickle"           % "0.4.1",


### PR DESCRIPTION
@juanpedromoreno does `sbt-microsites` need these dependencies? I didn't notice any of them when I grep'ed the codebase and the CI build passes without them.

@tpolecat noticed https://gitter.im/47deg/sbt-microsites?at=5989f779bc46472974651d23