### PR TITLE
User configurable footer

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -275,5 +275,4 @@ micrositeConfigYaml := ConfigYml(
 
 ```
 micrositeFooterText := Some("<b>Bob</b> the <i>Builder</i>")
-
 ```

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -89,7 +89,7 @@ micrositeGithubRepo := "sbt-microsites"
 ```
 
 - `micrositeGithubToken`: used for publishing the site when `github4s` is enabled. A [token with repo scope](https://github.com/settings/tokens/new?scopes=repo&description=sbt-microsites) is needed. None by default, but you can override it in this way:
- 
+
 ```
 micrositeGithubToken := getEnvVar("GITHUB_TOKEN")
 ```
@@ -269,4 +269,11 @@ micrositeConfigYaml := ConfigYml(
 |""".stripMargin,
   yamlPath = Some((resourceDirectory in Compile).value / "microsite" / "myconfig.yml")
 )
+```
+
+- `micrositeFooterText`: This setting allows the optional configuration of the second line in the footer. By default, it is set to `Some("""Website built with "Sbt-microsites © 2016 47 Degrees""")`. **This string is passed in unsanitized to the templating engine.**. If this setting is set to `None`, the second line is not displayed.
+
+```
+micrositeFooterText := Some("<b>Bob</b> the <i>Builder</i>")
+
 ```

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -133,6 +133,10 @@ trait MicrositeKeys {
     "Optional. Add custom Gitter sidecar Chat URL. By default is owner/repository."
   )
 
+  val micrositeFooterText: SettingKey[Option[String]] = SettingKey[Option[String]](
+    "Optional. Customize the second line in the footer."
+  )
+
   val publishMicrositeCommandKey: String = "publishMicrositeCommand"
 }
 
@@ -178,6 +182,9 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           highlightTheme = micrositeHighlightTheme.value,
           palette = micrositePalette.value,
           favicons = micrositeFavicons.value
+        ),
+        templateTexts = MicrositeTemplateTexts(
+          footer = micrositeFooterText.value
         ),
         configYaml = configWithAllCustomVariables,
         fileLocations = MicrositeFileLocations(

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -101,6 +101,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeAnalyticsToken := "",
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := s"${micrositeGithubOwner.value}/${micrositeGithubRepo.value}",
+    micrositeFooterText := Some(layouts.Layout.footer.toString),
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
     includeFilter in Jekyll := (includeFilter in makeSite).value,
     commands ++= Seq(publishMicrositeCommand)

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -26,6 +26,24 @@ import scalatags.Text.TypedTag
 import scalatags.Text.all._
 import scalatags.Text.tags2.{nav, title}
 
+object Layout {
+  val footer: TypedTag[String] =
+    p(
+      s"Website built with ",
+      a(
+        href := s"https://47deg.github.io/sbt-microsites/",
+        target := "_blank",
+        s"Sbt-microsites"
+      ),
+      s" - © 2016 ",
+      a(
+        href := s"https://www.47deg.com/",
+        target := "_blank",
+        s"47 Degrees"
+      )
+    )
+}
+
 abstract class Layout(config: MicrositeSettings) {
   implicitly(config)
 
@@ -199,54 +217,52 @@ abstract class Layout(config: MicrositeSettings) {
       |})
     """.stripMargin)
 
-  def globalFooter: TypedTag[String] =
+  def globalFooter: TypedTag[String] = {
+    val divs: Seq[TypedTag[String]] =
+      div(
+        cls := "row",
+        div(
+          cls := "col-xs-6",
+          p(
+            "{{ site.name }} is designed and developed by ",
+            a(
+              href := s"${config.identity.organizationHomepage}",
+              target := "_blank",
+              s"${config.identity.author}"))
+        ),
+        div(
+          cls := "col-xs-6",
+          p(
+            cls := "text-right",
+            a(
+              href := config.gitSiteUrl,
+              span(cls := s"fa ${config.gitHostingIconClass}"),
+              s"View on ${config.gitSettings.gitHostingService}"))
+        )
+      ) +: {
+        config.templateTexts.footer match {
+          case Some(text) =>
+            Seq(
+              div(
+                cls := "row",
+                div(
+                  cls := "col-xs-6",
+                  raw(text)
+                )
+              )
+            )
+          case None => Nil
+        }
+      }
+
     footer(
       id := "site-footer",
       div(
         cls := "container",
-        div(
-          cls := "row",
-          div(
-            cls := "col-xs-6",
-            p(
-              "{{ site.name }} is designed and developed by ",
-              a(
-                href := s"${config.identity.organizationHomepage}",
-                target := "_blank",
-                s"${config.identity.author}"))
-          ),
-          div(
-            cls := "col-xs-6",
-            p(
-              cls := "text-right",
-              a(
-                href := config.gitSiteUrl,
-                span(cls := s"fa ${config.gitHostingIconClass}"),
-                s"View on ${config.gitSettings.gitHostingService}"))
-          )
-        ),
-        div(
-          cls := "row",
-          div(
-            cls := "col-xs-6",
-            p(
-              s"Website built with ",
-              a(
-                href := s"https://47deg.github.io/sbt-microsites/",
-                target := "_blank",
-                s"Sbt-microsites"
-              ),
-              s" - © 2016 ",
-              a(
-                href := s"https://www.47deg.com/",
-                target := "_blank",
-                s"47 Degrees"
-              )
-            )
-          )
-        )
+        divs
       )
     )
+  }
 
   def buildCollapseMenu: TypedTag[String] =
     nav(

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -72,9 +72,12 @@ case class MicrositeVisualSettings(
     palette: Map[String, String],
     favicons: Seq[MicrositeFavicon])
 
+case class MicrositeTemplateTexts(footer: Option[String])
+
 case class MicrositeSettings(
     identity: MicrositeIdentitySettings,
     visualSettings: MicrositeVisualSettings,
+    templateTexts: MicrositeTemplateTexts,
     configYaml: ConfigYml,
     fileLocations: MicrositeFileLocations,
     urlSettings: MicrositeUrlSettings,

--- a/src/test/scala/microsites/LayoutTest.scala
+++ b/src/test/scala/microsites/LayoutTest.scala
@@ -79,6 +79,32 @@ class LayoutTest extends FunSuite with Checkers with Matchers with Arbitraries {
     check(property)
   }
 
+  test("globalFooter TypeTag should have the appropriate content") {
+
+    val property = forAll { implicit settings: MicrositeSettings ⇒
+      (settings.templateTexts.footer.isDefined) ==> {
+        val layout = buildParentLayout
+
+        layout.globalFooter.render contains settings.templateTexts.footer.get
+      }
+    }
+
+    check(property)
+  }
+
+  test("globalFooter TypeTag should have the appropriate number of </div>s") {
+
+    val property = forAll { implicit settings: MicrositeSettings ⇒
+      val layout = buildParentLayout
+
+      val footer = settings.templateTexts.footer
+
+      "</div>".r.findAllIn(layout.globalFooter.render).length === (4 + footer.fold(0)(_ => 2))
+    }
+
+    check(property)
+  }
+
   test("buildCollapseMenu TypeTag should be a `div`") {
 
     val property = forAll { implicit settings: MicrositeSettings ⇒

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -140,6 +140,7 @@ trait Arbitraries {
       micrositeKazariCodeMirrorTheme     ← Arbitrary.arbitrary[String]
       micrositeKazariDependencies        ← dependenciesListArbitrary.arbitrary
       micrositeKazariResolvers           ← Arbitrary.arbitrary[Seq[String]]
+      micrositeFooterText                ← Arbitrary.arbitrary[Option[String]]
     } yield
       MicrositeSettings(
         MicrositeIdentitySettings(
@@ -152,6 +153,7 @@ trait Arbitraries {
           twitterCreator,
           analytics),
         MicrositeVisualSettings(highlightTheme, palette, favicon),
+        MicrositeTemplateTexts(micrositeFooterText),
         micrositeConfigYaml,
         MicrositeFileLocations(
           micrositeImgDirectory,


### PR DESCRIPTION
Closes #218 

I'm not completely fond of `micrositeFooterText` as a setting key name because there are 2 lines in the footer. This setting only allows modifying the second the second line.