### PR TITLE
Releases 0.7.0 - Cross-built for sbt 0.13 and sbt 1.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0-SNAPSHOT"
+version in ThisBuild := "0.7.0"


### PR DESCRIPTION
Fixes https://github.com/47deg/sbt-microsites/issues/211

This PR releases a new version of `sbt-microsites` plugin, which it makes it compatible with `{1.0.x, 0.13.16}`.

This has been possible thanks to @suhasgaddam , who made the main work at  https://github.com/47deg/sbt-microsites/pull/221.