### PR TITLE
Releases 0.7.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.1-SNAPSHOT"
+version in ThisBuild := "0.7.1"


### PR DESCRIPTION
This new version will rely on tut 0.6.1. It was already fixed but not released.

See https://github.com/typelevel/cats/pull/1919 . This PR makes the new release.