### PR TITLE
Add support for custom Jekyll plugins

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -224,6 +224,12 @@ Each file (the map key) can be related to a specific configuration through the `
 2. Jekyll `layout` property.
 3. Other custom Jekyll properties that you might want to include in your document.
 
+- `micrositePluginsDirectory`: you can also introduce custom [Jekyll plugins](https://jekyllrb.com/docs/plugins/) in the generated microsite through the `micrositePluginsDirectory` setting. The plugin files in that folder will be automatically copied and imported by the plugin in your microsite. The default value is `(resourceDirectory in Compile).value / "microsite" / "plugins"` but you can override it like this:
+
+```
+micrositePluginsDirectory := (resourceDirectory in Compile).value / "site" / "plugins"
+```
+
 - `micrositePalette`: the default microsite style essentially uses eight colors. You can configure all of them, as seen below:
 
 ```

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -94,6 +94,8 @@ trait MicrositeKeys {
       "Optional. This key is useful when you want to include automatically markdown documents as a part of your microsite, and these files are located in different places from the tutSourceDirectory. The map key is related with the source file, the map value corresponds with the target relative file path and the document meta-information configuration. By default, the map is empty.")
   val micrositeExtraMdFilesOutput: SettingKey[File] = settingKey[File](
     "Optional. Microsite output location for extra-md files. Default is resourceManaged + '/jekyll/_extra_md'")
+  val micrositePluginsDirectory: SettingKey[File] = settingKey[File](
+    "Optional. Microsite Plugins directory. By default, it'll be the resourcesDirectory + '/microsite/plugins'")
   val micrositePalette: SettingKey[Map[String, String]] =
     settingKey[Map[String, String]]("Microsite palette")
   val micrositeFavicons: SettingKey[Seq[MicrositeFavicon]] = settingKey[Seq[MicrositeFavicon]](
@@ -196,7 +198,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositeExternalIncludesDirectory = micrositeExternalIncludesDirectory.value,
           micrositeDataDirectory = micrositeDataDirectory.value,
           micrositeExtraMdFiles = micrositeExtraMdFiles.value,
-          micrositeExtraMdFilesOutput = micrositeExtraMdFilesOutput.value
+          micrositeExtraMdFilesOutput = micrositeExtraMdFilesOutput.value,
+          micrositePluginsDirectory = micrositePluginsDirectory.value
         ),
         urlSettings = MicrositeUrlSettings(
           micrositeBaseUrl = micrositeBaseUrl.value,

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -75,6 +75,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeDataDirectory := (resourceDirectory in Compile).value / "microsite" / "data",
     micrositeExtraMdFiles := Map.empty,
     micrositeExtraMdFilesOutput := (resourceManaged in Compile).value / "jekyll" / "_extra_md",
+    micrositePluginsDirectory := (resourceDirectory in Compile).value / "microsite" / "plugins",
     micrositePalette := Map(
       "brand-primary"   -> "#02B4E5",
       "brand-secondary" -> "#1C2C52",

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -53,7 +53,8 @@ case class MicrositeFileLocations(
     micrositeExternalIncludesDirectory: File,
     micrositeDataDirectory: File,
     micrositeExtraMdFiles: Map[File, ExtraMdFileConfig],
-    micrositeExtraMdFilesOutput: File)
+    micrositeExtraMdFilesOutput: File,
+    micrositePluginsDirectory: File)
 
 case class MicrositeGitSettings(
     githubOwner: String,

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -64,6 +64,7 @@ class MicrositeHelper(config: MicrositeSettings) extends MicrositeHelperSpecific
     fw.copyJARResourcesTo(pluginURL, s"$targetDir$jekyllDir/", "img")
     fw.copyJARResourcesTo(pluginURL, s"$targetDir$jekyllDir/", "js")
     fw.copyJARResourcesTo(pluginURL, s"$targetDir$jekyllDir/", "highlight")
+    fw.copyJARResourcesTo(pluginURL, s"$targetDir$jekyllDir/", "plugins")
 
     fw.copyFilesRecursively(
       config.fileLocations.micrositeImgDirectory.getAbsolutePath,
@@ -83,6 +84,9 @@ class MicrositeHelper(config: MicrositeSettings) extends MicrositeHelperSpecific
     fw.copyFilesRecursively(
       config.fileLocations.micrositeDataDirectory.getAbsolutePath,
       s"$targetDir$jekyllDir/_data/")
+    fw.copyFilesRecursively(
+      config.fileLocations.micrositePluginsDirectory.getAbsolutePath,
+      s"$targetDir$jekyllDir/_plugins/")
 
     List(createConfigYML(targetDir), createPalette(targetDir)) ++
       createLayouts(targetDir) ++ createPartialLayout(targetDir) ++ createFavicons(targetDir)

--- a/src/sbt-test/microsites/change-default-paths/build.sbt
+++ b/src/sbt-test/microsites/change-default-paths/build.sbt
@@ -14,3 +14,4 @@ micrositeExtraMdFilesOutput := (target in Compile).value / "extra_md_override"
 
 micrositeImgDirectory := (resourceDirectory in Compile).value / "images"
 micrositeCssDirectory := (resourceDirectory in Compile).value / "styles"
+micrositePluginsDirectory := (resourceDirectory in Compile).value / "plugins"

--- a/src/sbt-test/microsites/change-default-paths/src/main/resources/plugins/GitterTag.rb
+++ b/src/sbt-test/microsites/change-default-paths/src/main/resources/plugins/GitterTag.rb
@@ -1,0 +1,9 @@
+module Jekyll
+  class GitterTag < Liquid::Tag
+    def render(context)
+      "[gitter](javascript:window.gitter.chat.defaultChat.toggleChat(true))"
+    end
+  end
+end
+
+Liquid::Template.register_tag('gitter', Jekyll::GitterTag)

--- a/src/sbt-test/microsites/change-default-paths/src/main/tut/docs.md
+++ b/src/sbt-test/microsites/change-default-paths/src/main/tut/docs.md
@@ -22,3 +22,4 @@ Suspendisse sed faucibus ex. Aliquam at ultrices lacus, sit amet tempus augue. F
 Vivamus in nisi laoreet, mattis erat eget, ornare ligula. Aliquam rhoncus lorem ac hendrerit sagittis. In hac habitasse platea dictumst. 
 
 Maecenas ut facilisis eros. Proin nisl urna, pharetra ut semper convallis, consequat aliquam turpis. Nam a magna varius, egestas nisl nec, pharetra sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Praesent libero magna, ornare nec odio id, cursus porta ante. Maecenas volutpat, neque eget bibendum faucibus, sapien nisi tincidunt eros, eu scelerisque lorem ante vel justo. Nullam euismod dolor sed lacus dapibus, dictum egestas dolor accumsan.
+{% gitter %}

--- a/src/sbt-test/microsites/change-default-paths/test
+++ b/src/sbt-test/microsites/change-default-paths/test
@@ -8,6 +8,7 @@ $ exists target/scala-2.11/resource_managed/main/jekyll/img/scala.png
 $ exists target/scala-2.11/resource_managed/main/jekyll/img/sbt.png
 $ exists target/scala-2.11/resource_managed/main/jekyll/css/override-1.css
 $ exists target/scala-2.11/resource_managed/main/jekyll/css/override-2.css
+$ exists target/scala-2.11/resource_managed/main/jekyll/_plugins/GitterTag.rb
 
 # check images and css at site folder
 

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -124,6 +124,7 @@ trait Arbitraries {
       micrositeDataDirectory             ← Arbitrary.arbitrary[File]
       micrositeExtraMdFiles              ← markdownMapArbitrary.arbitrary
       micrositeExtraMdFilesOutput        ← Arbitrary.arbitrary[File]
+      micrositePluginsDirectory          ← Arbitrary.arbitrary[File]
       micrositeBaseUrl                   ← Arbitrary.arbitrary[String]
       micrositeDocumentationUrl          ← Arbitrary.arbitrary[String]
       palette                            ← paletteMapArbitrary.arbitrary
@@ -164,7 +165,8 @@ trait Arbitraries {
           micrositeExternalIncludesDirectory,
           micrositeDataDirectory,
           micrositeExtraMdFiles,
-          micrositeExtraMdFilesOutput
+          micrositeExtraMdFilesOutput,
+          micrositePluginsDirectory
         ),
         MicrositeUrlSettings(micrositeBaseUrl, micrositeDocumentationUrl),
         MicrositeGitSettings(


### PR DESCRIPTION
This PR adds support for custom Jekyll plugins, introducing a configurable `micrositePluginsDirectory` which defaults to `resources/microsite/plugins`.

This is essentially a port of https://github.com/scalacenter/scalafix/pull/386/commits/24c289c5aaf3842c3ffbd0a05c91c9ab8f64cf33, which turned out to be very useful for defining custom liquid tags.