### PR TITLE
Updates tut 0.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - scala: 2.12.3
       env:
-        - SBT_VERSION=1.0.1
+        - SBT_VERSION=1.0.2
     - scala: 2.10.6
       env:
         - SBT_VERSION=0.13.16
@@ -33,7 +33,7 @@ after_success:
       if grep -q "SNAPSHOT" version.sbt; then
         sbt ^^$SBT_VERSION publish;
       else
-        if [ "$SBT_VERSION" = "1.0.1" ]; then
+        if [ "$SBT_VERSION" = "1.0.2" ]; then
           sbt ^^$SBT_VERSION orgUpdateDocFiles;
           git reset --hard HEAD;
           git clean -f;

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -42,7 +42,7 @@ object ProjectPlugin extends AutoPlugin {
 
         val (tutPluginVersion, scrimageVersion) = sbtVersionValue match {
           case sbtV.`0.13` => ("0.5.5", "2.1.7")
-          case sbtV.`1.0`  => ("0.6.1", "2.1.8")
+          case sbtV.`1.0`  => ("0.6.2", "2.1.8")
         }
 
         Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.1
+sbt.version = 1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.9")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.9")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -24,7 +24,7 @@ import microsites._
 import microsites.layouts._
 import net.jcazevedo.moultingyaml.{YamlObject, _}
 import sbt._
-import sbtorgpolicies.io._
+import sbtorgpolicies.io.FileWriter
 import sbtorgpolicies.io.syntax._
 
 import scala.io.Source

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.5-SNAPSHOT"
+version in ThisBuild := "0.7.5"


### PR DESCRIPTION
This PR updates to tut version `0.6.2` through https://github.com/47deg/sbt-org-policies.

It releases a new patch version (`0.7.5`).