### PR TITLE
Updates missed tut 0.5.6 for sbt 0.13.x

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -41,7 +41,7 @@ object ProjectPlugin extends AutoPlugin {
         val scalaBinaryVersionValue = (scalaBinaryVersion in update).value
 
         val (tutPluginVersion, scrimageVersion) = sbtVersionValue match {
-          case sbtV.`0.13` => ("0.5.5", "2.1.7")
+          case sbtV.`0.13` => ("0.5.6", "2.1.7")
           case sbtV.`1.0`  => ("0.6.2", "2.1.8")
         }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.9")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.10")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.6-SNAPSHOT"
+version in ThisBuild := "0.7.6"


### PR DESCRIPTION
In the previous release, we missed bumping the tut version for sbt `0.13.x` (`0.5.6`).

This PR will release `0.7.6`, which will use the latest `tut` versions for both sbt `1.0.x` and `0.13.x`.