### PR TITLE
Disabling kazari in DocsLayout and kazari styles if kazari is not required

### DIFF
--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -27,7 +27,11 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
   override def render: TypedTag[String] = {
     html(
       commonHead,
-      body(cls := "docs", sideBarAndContent, scriptsDocs, kazariEnableScript)
+      body(
+        cls := "docs",
+        sideBarAndContent,
+        scriptsDocs,
+        if (config.micrositeKazariSettings.micrositeKazariEnabled) kazariEnableScript else "")
     )
   }
 

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -156,6 +156,13 @@ abstract class Layout(config: MicrositeSettings) {
       link(rel := "stylesheet", href := css)
     }
 
+    val kazariStyles = List(
+      link(rel := "stylesheet", href := s"{{site.baseurl}}/css/kazari-style.css"),
+      link(
+        rel := "stylesheet",
+        href := s"{{site.baseurl}}/css/${config.micrositeKazariSettings.micrositeKazariCodeMirrorTheme}.css")
+    )
+
     List(
       link(
         rel := "stylesheet",
@@ -168,12 +175,10 @@ abstract class Layout(config: MicrositeSettings) {
         href := s"{{site.url}}{{site.baseurl}}/highlight/styles/${config.visualSettings.highlightTheme}.css"),
       link(rel := "stylesheet", href := s"{{site.baseurl}}/css/style.css"),
       link(rel := "stylesheet", href := s"{{site.baseurl}}/css/palette.css"),
-      link(rel := "stylesheet", href := s"{{site.baseurl}}/css/codemirror.css"),
-      link(rel := "stylesheet", href := s"{{site.baseurl}}/css/kazari-style.css"),
-      link(
-        rel := "stylesheet",
-        href := s"{{site.baseurl}}/css/${config.micrositeKazariSettings.micrositeKazariCodeMirrorTheme}.css")
-    ) ++ customCssList ++ customCDNList
+      link(rel := "stylesheet", href := s"{{site.baseurl}}/css/codemirror.css")
+    ) ++ customCssList ++ customCDNList ++ (if (config.micrositeKazariSettings.micrositeKazariEnabled)
+                                              kazariStyles
+                                            else Nil)
   }
 
   def scripts: List[TypedTag[String]] = {


### PR DESCRIPTION
This PR disables or enables kazari in `DocsLayout` and kazari's styles in `Layout`, depending of the `micrositeKazariEnabled` setting.

@jdesiloniz @juanpedromoreno  could you please review?

Thanks!