### PR TITLE
Change GA script parsing mode for smoother navigation jumps

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -27,7 +27,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin(%("sbt-ghpages", true)),
       addSbtPlugin(%("sbt-site", true)),
       libraryDependencies ++= Seq(
-        %%("org-policies-core", "0.8.14"),
+        %%("org-policies-core", "0.8.17"),
         %%("moultingyaml"),
         %%("scalatags"),
         %%("scalactic"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.14")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.17")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -62,7 +62,7 @@ abstract class Layout(config: MicrositeSettings) {
 
   val ganalytics: Option[TypedTag[String]] =
     if (config.identity.analytics.nonEmpty)
-      Some(script(s"""
+      Some(script(attr("async") := "async")(s"""
       |(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       |(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       |m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -127,7 +127,7 @@ abstract class Layout(config: MicrositeSettings) {
       meta(name := "twitter:image", content := s"${config.identity.homepage}img/poster.png"),
       meta(name := "twitter:description", content := config.identity.description),
       meta(name := "twitter:card", content := "summary_large_image")
-    ) ++ twitter.toList ++ twitterCreator.toList ++ kazariDep.toList ++ kazariRes.toList ++ ganalytics.toList
+    ) ++ twitter.toList ++ twitterCreator.toList ++ kazariDep.toList ++ kazariRes.toList
 
   def favicons: List[TypedTag[String]] =
     (if (config.visualSettings.favicons.nonEmpty) {
@@ -178,7 +178,7 @@ abstract class Layout(config: MicrositeSettings) {
       link(rel := "stylesheet", href := s"{{site.baseurl}}/css/codemirror.css")
     ) ++ customCssList ++ customCDNList ++ (if (config.micrositeKazariSettings.micrositeKazariEnabled)
                                               kazariStyles
-                                            else Nil)
+                                            else Nil) ++ ganalytics.toList
   }
 
   def scripts: List[TypedTag[String]] = {


### PR DESCRIPTION
* Upgrade sbt-org-policies version dependencies to 0.8.17.

* Set async attribute for the GA script code, to not make the rest of
the HTML parsing get stopped by it.

* Position to load and parse the Google Analytics code after the rest of
the needed dependencies, specially after the CSS styling files, thus
making the render smoother between navigation jumps.

This fixes #75 