### PR TITLE
Bump ruby version to 2.2.8 in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.3 --install --fuzzy
+  - rvm use 2.2.8 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -39,7 +39,7 @@ This is needed in order to install and be able to use the `jekyll` gem from othe
 
 ```bash
 install:
-  - rvm use 2.2.3 --install --fuzzy
+  - rvm use 2.2.8 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/docs/src/main/tut/docs/publish-with-travis.md
+++ b/docs/src/main/tut/docs/publish-with-travis.md
@@ -96,7 +96,7 @@ before_install:
   scripts/decrypt-keys.sh; fi
 - export PATH=${PATH}:./vendor/bundle
 install:
-- rvm use 2.2.3 --install --fuzzy
+- rvm use 2.2.8 --install --fuzzy
 - gem update --system
 - gem install sass
 - gem install jekyll -v 3.2.1


### PR DESCRIPTION
As of 6 Dec 2017, Ruby 2.2.3 does not meet the gem constraint of build_dep 1.5.0 [1], a transitive dependency of jekyll 3.2.1. It's a temporary fix.

[1] https://travis-ci.org/tpolecat/doobie/jobs/312232582