### PR TITLE
Add micrositeStaticDirectory feature

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -7,20 +7,20 @@ title: Configuring the Microsite
 
 The following are the `sbt` settings that you can use to make adjustments to your microsite regarding deployment, configuration, and appearance. Not all of these settings are mandatory, since most of them have default values, as we'll see briefly.
 
-Before you begin to detail the settings, the **sbt-microsites** plugin will use regular sbt configurations from your `build.sbt` file. In order to setup the microsite with minimal effort, all of the configurations are used as default values: 
-   
+Before you begin to detail the settings, the **sbt-microsites** plugin will use regular sbt configurations from your `build.sbt` file. In order to setup the microsite with minimal effort, all of the configurations are used as default values:
+
 ## Regular SBT Settings
-   
+
 - `name`: default value for the microsite name.
 - `description`: value by default used for the microsite description.
 - `organizationName`: used as the microsite author by default.
 - `organizationHomepage`: used as the default microsite homepage.
 
-However, you can override these default settings by using the ones provided by the plugin, which we will describe in detail in the next section. 
+However, you can override these default settings by using the ones provided by the plugin, which we will describe in detail in the next section.
 
 ## Microsite SBT Settings
 
-We tried to provide all of the parameters that are potentially needed to configure any microsite. If you think that something additional needs adding, please let us know! We're open to suggestions and contributions. 
+We tried to provide all of the parameters that are potentially needed to configure any microsite. If you think that something additional needs adding, please let us know! We're open to suggestions and contributions.
 
 - `micrositeName`: the microsite name. As we mentioned previously, by default, it's taken from the sbt setting `name`. Sometimes, it isn't the default behavior so you can override it like this:
 
@@ -201,6 +201,14 @@ micrositeDataDirectory := (resourceDirectory in Compile).value / "site" / "mydat
 ```
 
 In the Documentation **Menu** case, as you can see in the [layouts](layouts.html) section, you need to create a file named as `menu.yml` under the `micrositeDataDirectory` setting.
+
+- `micrositeStaticDirectory`: you can also provide a static directory to your Jekyll site through the `micrositeStaticDirectory` setting. It's based on the idea of [Jekyll Static Files](https://jekyllrb.com/docs/static-files/). The default value is `(resourceDirectory in Compile).value / "microsite" / "static"` but you can override it like this:
+
+```
+micrositeStaticDirectory := (resourceDirectory in Compile).value / "site" / "mystaticfiles"
+```
+
+The directory will be copied as-is, but no process will be applied to any file on it, so the responsibility of loading/linking/use them on a layout is yours.
 
 - `micrositeExtraMdFiles`: this setting can be handy if you want to include additional markdown files in your site, and these files are not located in the same place in your `tut` directory. By default, the setting is set up as an empty map. You can override it, in this way:
 

--- a/kazari/src/main/scala/kazari/KazariPlugin.scala
+++ b/kazari/src/main/scala/kazari/KazariPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kazari/src/main/scala/kazari/KazariUIBehavior.scala
+++ b/kazari/src/main/scala/kazari/KazariUIBehavior.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kazari/src/main/scala/kazari/codemirror/CodeMirrorHelper.scala
+++ b/kazari/src/main/scala/kazari/codemirror/CodeMirrorHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kazari/src/main/scala/kazari/domhelper/DOMHelper.scala
+++ b/kazari/src/main/scala/kazari/domhelper/DOMHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kazari/src/main/scala/kazari/domhelper/DOMTags.scala
+++ b/kazari/src/main/scala/kazari/domhelper/DOMTags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.17")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.21")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/src/main/scala-2.12/microsites/util/MicrositeHelperSpecific.scala
+++ b/src/main/scala-2.12/microsites/util/MicrositeHelperSpecific.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -89,6 +89,8 @@ trait MicrositeKeys {
   val micrositeDataDirectory: SettingKey[File] = settingKey[File](
     "Optional. Microsite Data directory, useful to define the microsite data files " +
       "(https://jekyllrb.com/docs/datafiles/). By default, it'll be the resourcesDirectory + '/microsite/data'")
+  val micrositeStaticDirectory: SettingKey[File] = settingKey[File](
+    "Optional. Microsite static files directory. By default, it'll be the resourcesDirectory + '/microsite/static'")
   val micrositeExtraMdFiles: SettingKey[Map[File, ExtraMdFileConfig]] =
     settingKey[Map[File, ExtraMdFileConfig]](
       "Optional. This key is useful when you want to include automatically markdown documents as a part of your microsite, and these files are located in different places from the tutSourceDirectory. The map key is related with the source file, the map value corresponds with the target relative file path and the document meta-information configuration. By default, the map is empty.")
@@ -199,6 +201,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositeExternalLayoutsDirectory = micrositeExternalLayoutsDirectory.value,
           micrositeExternalIncludesDirectory = micrositeExternalIncludesDirectory.value,
           micrositeDataDirectory = micrositeDataDirectory.value,
+          micrositeStaticDirectory = micrositeStaticDirectory.value,
           micrositeExtraMdFiles = micrositeExtraMdFiles.value,
           micrositeExtraMdFilesOutput = micrositeExtraMdFilesOutput.value,
           micrositePluginsDirectory = micrositePluginsDirectory.value

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -73,6 +73,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeExternalLayoutsDirectory := (resourceDirectory in Compile).value / "microsite" / "layouts",
     micrositeExternalIncludesDirectory := (resourceDirectory in Compile).value / "microsite" / "includes",
     micrositeDataDirectory := (resourceDirectory in Compile).value / "microsite" / "data",
+    micrositeStaticDirectory := (resourceDirectory in Compile).value / "microsite" / "static",
     micrositeExtraMdFiles := Map.empty,
     micrositeExtraMdFilesOutput := (resourceManaged in Compile).value / "jekyll" / "_extra_md",
     micrositePluginsDirectory := (resourceDirectory in Compile).value / "microsite" / "plugins",

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/layouts/HomeLayout.scala
+++ b/src/main/scala/microsites/layouts/HomeLayout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/layouts/MenuPartialLayout.scala
+++ b/src/main/scala/microsites/layouts/MenuPartialLayout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/layouts/PageLayout.scala
+++ b/src/main/scala/microsites/layouts/PageLayout.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -51,6 +51,7 @@ case class MicrositeFileLocations(
     micrositeExternalLayoutsDirectory: File,
     micrositeExternalIncludesDirectory: File,
     micrositeDataDirectory: File,
+    micrositeStaticDirectory: File,
     micrositeExtraMdFiles: Map[File, ExtraMdFileConfig],
     micrositeExtraMdFilesOutput: File,
     micrositePluginsDirectory: File)

--- a/src/main/scala/microsites/util/BuildHelper.scala
+++ b/src/main/scala/microsites/util/BuildHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -82,6 +82,9 @@ class MicrositeHelper(config: MicrositeSettings) extends MicrositeHelperSpecific
       config.fileLocations.micrositeDataDirectory.getAbsolutePath,
       s"$targetDir$jekyllDir/_data/")
     copyFilesRecursively(
+      config.fileLocations.micrositeStaticDirectory.getAbsolutePath,
+      s"$targetDir$jekyllDir/${config.fileLocations.micrositeStaticDirectory.getName}/")
+    copyFilesRecursively(
       config.fileLocations.micrositePluginsDirectory.getAbsolutePath,
       s"$targetDir$jekyllDir/_plugins/")
 

--- a/src/test/scala/microsites/DocsLayoutTest.scala
+++ b/src/test/scala/microsites/DocsLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/HomeLayoutTest.scala
+++ b/src/test/scala/microsites/HomeLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/LayoutTest.scala
+++ b/src/test/scala/microsites/LayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/MenuPartialLayoutTest.scala
+++ b/src/test/scala/microsites/MenuPartialLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/PageLayoutTest.scala
+++ b/src/test/scala/microsites/PageLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2018 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -122,6 +122,7 @@ trait Arbitraries {
       micrositeExternalLayoutsDirectory  ← Arbitrary.arbitrary[File]
       micrositeExternalIncludesDirectory ← Arbitrary.arbitrary[File]
       micrositeDataDirectory             ← Arbitrary.arbitrary[File]
+      micrositeStaticDirectory           ← Arbitrary.arbitrary[File]
       micrositeExtraMdFiles              ← markdownMapArbitrary.arbitrary
       micrositeExtraMdFilesOutput        ← Arbitrary.arbitrary[File]
       micrositePluginsDirectory          ← Arbitrary.arbitrary[File]
@@ -165,6 +166,7 @@ trait Arbitraries {
           micrositeExternalLayoutsDirectory,
           micrositeExternalIncludesDirectory,
           micrositeDataDirectory,
+          micrositeStaticDirectory,
           micrositeExtraMdFiles,
           micrositeExtraMdFilesOutput,
           micrositePluginsDirectory

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.14-SNAPSHOT"
+version in ThisBuild := "0.7.14"


### PR DESCRIPTION
* Update sbt-org-policies dependency to 0.8.21
* Update copyright notice to 2018
* Add `micrositeStaticDirectory` feature, which by setting it will copy a directory without processing it in any way to the generated Jekyll directory
* Update documentation reflecting this new feature
* Release a new version, 0.7.14


This closes #250