### PR TITLE
allows hide Github and Social links in `docs` layout

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -116,6 +116,12 @@ micrositeGitHostingUrl := "https://gitlab.com/gitlab-org/gitlab-ce"
 micrositeAnalyticsToken := 'UA-XXXXX-Y'
 ```
 
+- `micrositeGithubLinks`: This setting defines whether to show/hide GitHub links for stars and forks in docs layout. By default, it is enabled.
+
+```
+micrositeGithubLinks := true
+```
+
 - `micrositeGitterChannel`: This setting is used to enabled the Gitter sidecar Channel functionality, by default is enabled. The chat room is taken from `micrositeGithubOwner` and `micrositeGithubRepo`.
 
 ```
@@ -129,6 +135,12 @@ micrositeGitterChannelUrl := "47deg/sbt-microsites"
 ```
 
 - `micrositeHighlightTheme`: by default, the theme of Highlight.js is [default](https://highlightjs.org/static/demo/), however, you can configure it to a different theme thanks to this setting:
+
+- `micrositeShareOnSocial`: This setting defines whether to show/hide the social media buttons in docs layout. By default, it is enabled.
+
+```
+micrositeShareOnSocial := true
+```
 
 ```
 micrositeHighlightTheme := "monokai"

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -68,7 +68,10 @@ trait MicrositeKeys {
     settingKey[String]("Microsite organisation homepage")
   val micrositeTwitter: SettingKey[String]        = settingKey[String]("Microsite twitter")
   val micrositeTwitterCreator: SettingKey[String] = settingKey[String]("Microsite twitter")
-  val micrositeBaseUrl: SettingKey[String]        = settingKey[String]("Microsite site base url")
+  val micrositeShareOnSocial: SettingKey[Boolean] = settingKey[Boolean](
+    "Optional. Includes links to share on social media in the layout. Enabled by default."
+  )
+  val micrositeBaseUrl: SettingKey[String] = settingKey[String]("Microsite site base url")
   val micrositeDocumentationUrl: SettingKey[String] =
     settingKey[String]("Microsite site documentation url")
   val micrositeHighlightTheme: SettingKey[String] = settingKey[String]("Microsite Highlight Theme")
@@ -106,6 +109,8 @@ trait MicrositeKeys {
   val micrositeGithubRepo: SettingKey[String]  = settingKey[String]("Microsite Github repo")
   val micrositeGithubToken: SettingKey[Option[String]] =
     settingKey[Option[String]]("Microsite Github token for pushing the microsite")
+  val micrositeGithubLinks: SettingKey[Boolean] = settingKey[Boolean](
+    "Optional. Includes Github links (forks, stars) in the layout. Enabled by default.")
   val micrositeKazariEnabled: SettingKey[Boolean] =
     settingKey[Boolean]("Optional. Includes Kazari plugin functionality. Disabled by default.")
   val micrositeKazariEvaluatorUrl: SettingKey[String] = settingKey[String](
@@ -187,7 +192,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
         visualSettings = MicrositeVisualSettings(
           highlightTheme = micrositeHighlightTheme.value,
           palette = micrositePalette.value,
-          favicons = micrositeFavicons.value
+          favicons = micrositeFavicons.value,
+          shareOnSocial = micrositeShareOnSocial.value
         ),
         templateTexts = MicrositeTemplateTexts(
           footer = micrositeFooterText.value
@@ -228,6 +234,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
             case GitHub => micrositeGithubRepo.value
             case _      => ""
           },
+          githubLinks = micrositeGithubLinks.value,
           gitHostingService = micrositeGitHostingService.value.name,
           gitHostingUrl = micrositeGitHostingUrl.value,
           gitSidecarChat = micrositeGitterChannel.value,

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -63,6 +63,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeDocumentationUrl := "",
     micrositeTwitter := "",
     micrositeTwitterCreator := "",
+    micrositeShareOnSocial := true,
     micrositeHighlightTheme := "default",
     micrositeConfigYaml := ConfigYml(
       yamlPath = Some((resourceDirectory in Compile).value / "microsite" / "_config.yml")),
@@ -105,6 +106,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := s"${micrositeGithubOwner.value}/${micrositeGithubRepo.value}",
     micrositeFooterText := Some(layouts.Layout.footer.toString),
+    micrositeGithubLinks := true,
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
     includeFilter in Jekyll := (includeFilter in makeSite).value,
     commands ++= Seq(publishMicrositeCommand)

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -36,8 +36,42 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
   }
 
   def sideBarAndContent: TypedTag[String] = {
-    // format: off
+
     val text = s"${config.identity.name} ${config.identity.description}"
+
+    def githubLinks: Seq[TypedTag[String]] = {
+      if (config.gitSettings.githubLinks) {
+        Seq(
+          li(
+            id := "gh-eyes-item",
+            cls := "hidden-xs",
+            a(
+              href := config.gitSiteUrl,
+              i(cls := "fa fa-eye"),
+              span("WATCH", span(id := "eyes", cls := "label label-default", "--")))),
+          li(
+            id := "gh-stars-item",
+            cls := "hidden-xs",
+            a(
+              href := config.gitSiteUrl,
+              i(cls := "fa fa-star-o"),
+              span("STARS", span(id := "stars", cls := "label label-default", "--")))
+          )
+        )
+      } else Seq.empty
+    }
+
+    def shareOnSocial: Seq[TypedTag[String]] = {
+      if (config.visualSettings.shareOnSocial) {
+        Seq(
+          li(a(href := "#", onclick := s"shareSiteTwitter('$text');", i(cls := "fa fa-twitter"))),
+          li(a(href := "#", onclick := s"shareSiteFacebook('$text');", i(cls := "fa fa-facebook"))),
+          li(a(href := "#", onclick := "shareSiteGoogle();", i(cls := "fa fa-google-plus")))
+        )
+      } else Seq.empty
+    }
+
+    // format: off
     div(id := "wrapper",
       div(id := "sidebar-wrapper", buildSidebar),
       div(id := "page-content-wrapper",
@@ -49,21 +83,8 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
                   a(href := "#menu-toggle", id := "menu-toggle", i(cls := "fa fa-bars", aria.hidden := "true"))
                 ),
                 ul(cls := "pull-right",
-                  li(id := "gh-eyes-item", cls := "hidden-xs",
-                    a(href := config.gitSiteUrl,
-                      i(cls := "fa fa-eye"),
-                      span("WATCH", span(id := "eyes", cls := "label label-default", "--"))
-                    )
-                  ),
-                  li(id := "gh-stars-item", cls := "hidden-xs",
-                    a(href := config.gitSiteUrl,
-                      i(cls := "fa fa-star-o"),
-                      span("STARS", span(id := "stars", cls := "label label-default", "--"))
-                    )
-                  ),
-                  li(a(href := "#", onclick := s"shareSiteTwitter('$text');", i(cls := "fa fa-twitter"))),
-                  li(a(href := "#", onclick := s"shareSiteFacebook('$text');", i(cls := "fa fa-facebook"))),
-                  li(a(href := "#", onclick := "shareSiteGoogle();", i(cls := "fa fa-google-plus")))
+                  githubLinks,
+                  shareOnSocial
                 )
               )
             )

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -59,6 +59,7 @@ case class MicrositeFileLocations(
 case class MicrositeGitSettings(
     githubOwner: String,
     githubRepo: String,
+    githubLinks: Boolean,
     gitHostingService: MicrositeKeys.GitHostingService,
     gitHostingUrl: String,
     gitSidecarChat: Boolean,
@@ -71,7 +72,8 @@ case class MicrositeFavicon(filename: String, sizeDescription: String)
 case class MicrositeVisualSettings(
     highlightTheme: String,
     palette: Map[String, String],
-    favicons: Seq[MicrositeFavicon])
+    favicons: Seq[MicrositeFavicon],
+    shareOnSocial: Boolean)
 
 case class MicrositeTemplateTexts(footer: Option[String])
 

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -134,8 +134,10 @@ trait Arbitraries {
       githubRepo                         ← Arbitrary.arbitrary[String]
       gitHostingService                  ← Arbitrary.arbitrary[GitHostingService]
       gitHostingUrl                      ← Arbitrary.arbitrary[String]
+      githubLinks                        ← Arbitrary.arbitrary[Boolean]
       gitSidecarChat                     ← Arbitrary.arbitrary[Boolean]
       gitSidecarChatUrl                  ← Arbitrary.arbitrary[String]
+      shareOnSocial                      ← Arbitrary.arbitrary[Boolean]
       micrositeKazariEnabled             ← Arbitrary.arbitrary[Boolean]
       micrositeKazariEvaluatorUrl        ← Arbitrary.arbitrary[String]
       micrositeKazariEvaluatorToken      ← Arbitrary.arbitrary[String]
@@ -155,7 +157,7 @@ trait Arbitraries {
           twitter,
           twitterCreator,
           analytics),
-        MicrositeVisualSettings(highlightTheme, palette, favicon),
+        MicrositeVisualSettings(highlightTheme, palette, favicon, shareOnSocial),
         MicrositeTemplateTexts(micrositeFooterText),
         micrositeConfigYaml,
         MicrositeFileLocations(
@@ -175,6 +177,7 @@ trait Arbitraries {
         MicrositeGitSettings(
           githubOwner,
           githubRepo,
+          githubLinks,
           gitHostingService,
           gitHostingUrl,
           gitSidecarChat,


### PR DESCRIPTION
- adds setting key `micrositeShareOnSocial` whether to show/hide the
share on social buttons in docs layout
- adds setting key `micrositeGithubLinks` whether to show/hide GitHub
links for stars and forks in docs layout

Please let me know whether you are fine with this addition or if I'm missing something. Also, naming and correct locations for the settings are up for discussion…