### PR TITLE
Bumps sbt-org-policies version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.21")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.28")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.17-SNAPSHOT"
+version in ThisBuild := "0.7.17"


### PR DESCRIPTION
This PR solves #259.

I am bumping `sbt-org-policies` to `0.8.28`. This version has the latest version of `tut` required by @BennyHill.

