### PR TITLE
Update tut to 0.6.4 for incomplete input fix

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -40,7 +40,7 @@ object ProjectPlugin extends AutoPlugin {
 
         val (tutPluginVersion, scrimageVersion) = sbtBinaryVersionValue match {
           case "0.13" => ("0.5.6", "2.1.7")
-          case "1.0"  => ("0.6.2", "2.1.8")
+          case "1.0"  => ("0.6.4", "2.1.8")
         }
 
         Seq(


### PR DESCRIPTION
Tut 0.6.4 adds a fix for https://github.com/tpolecat/tut/issues/65, which
makes sure that incomplete input does not pass compilation