### PR TITLE
Release - Updating to tut 0.6.6

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.21-SNAPSHOT"
+version in ThisBuild := "0.7.21"


### PR DESCRIPTION
This new patch release (0.7.21) will use the new version of `tut`: 0.6.6, thanks to @xuwei-k 