### PR TITLE
gitSiteURL supports MicrositeKeys.GitHub and gitHostingUrl

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -110,7 +110,7 @@ micrositeGithubToken := getEnvVar("GITHUB_TOKEN")
 micrositePushSiteWith := GitHub4s
 ```
 
-- `micrositeGitHostingService` and `micrositeGitHostingUrl`: in order to specify a hosting service other than `GitHub`:
+- `micrositeGitHostingService` and `micrositeGitHostingUrl`: in order to specify a hosting service other than `GitHub`. If you are using a privately hosted GitHub instance you can set the `micrositeGitHostingUrl` to override the default github.com and repo name configuration.
 
 ```
 micrositeGitHostingService := GitLab

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -91,8 +91,8 @@ case class MicrositeSettings(
     micrositeKazariSettings: KazariSettings) {
 
   def gitSiteUrl: String = {
-    gitSettings.gitHostingService match {
-      case MicrositeKeys.GitHub =>
+    (gitSettings.gitHostingService, gitSettings.gitHostingUrl) match {
+      case (MicrositeKeys.GitHub, "") =>
         s"https://github.com/${gitSettings.githubOwner}/${gitSettings.githubRepo}"
       case _ => gitSettings.gitHostingUrl
     }


### PR DESCRIPTION
I'm working with sbt-microsites on projects that are hosted on private Github instances. Currently the gitSiteUrl sets the URL to github.com if GitHub is the gitHostingService. This means I can't correctly link to my hosted Github repos with the default links in the template header, footer, and homepage. 

This pull request updated the gitSiteUrl to check the `gitHostingService` and `gitHostingUrl` attributes. If it is MicrositeKeys.GitHub and an empty string it returns the existing formatted URL, otherwise it returns the user set  `gitHostingUrl`.