### PR TITLE
add 'Edit Page' feature to doc pages

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -327,3 +327,9 @@ micrositeConfigYaml := ConfigYml(
 ```
 micrositeFooterText := Some("<b>Bob</b> the <i>Builder</i>")
 ```
+
+- `micrositeEditButtonText`: This setting allows the optional inclusion and configuration of an edit button on pages with the docs layout. By default, it is set to `None` and not visible. If the setting is set to `Some` with given text, that text will appear on the button at the bottom of the page. The button links to the edit view of the page in it's repository. **This string is passed in unsanitized to the templating engine.**
+
+```
+micrositeEditButtonText := Some("Improve this page")
+```

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -328,8 +328,13 @@ micrositeConfigYaml := ConfigYml(
 micrositeFooterText := Some("<b>Bob</b> the <i>Builder</i>")
 ```
 
-- `micrositeEditButtonText`: This setting allows the optional inclusion and configuration of an edit button on pages with the docs layout. By default, it is set to `None` and not visible. If the setting is set to `Some` with given text, that text will appear on the button at the bottom of the page. The button links to the edit view of the page in it's repository. **This string is passed in unsanitized to the templating engine.**
+- `micrositeEditButtonText`: This setting allows the optional inclusion and configuration of an edit button on pages
+with the docs layout. The button links to the given path of the page in it's repository.
+By default, it is set to `None` and not visible. To enable, set the MicrositeEditButton with text
+for the button and the basePath for the file. The basePath is comprised of the file URL excluding the top-level
+repository URL and should include the dynamic property `{{page.path}}` that will be generated for each page when Jekyll
+compiles the site.  **The strings are passed in unsanitized to the templating engine.**
 
 ```
-micrositeEditButtonText := Some("Improve this page")
+micrositeEditButton := Some(MicrositeEditButton("Improve this Page", "/edit/master/docs/src/main/tut/{{ page.path }}"))
 ```

--- a/src/main/resources/_sass/_docs.scss
+++ b/src/main/resources/_sass/_docs.scss
@@ -198,6 +198,10 @@
     }
 }
 
+.edit-button {
+    padding: 0 30px 10px;
+}
+
 @media (min-width: 768px) {
     #wrapper {
         padding-left: 250px;

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -152,6 +152,10 @@ trait MicrositeKeys {
     "Optional. Customize the second line in the footer."
   )
 
+  val micrositeEditButtonText: SettingKey[Option[String]] = settingKey[Option[String]](
+    "Optional. Add a button with given string in DocsLayout pages that links to the file in the repository."
+  )
+
   val publishMicrositeCommandKey: String = "publishMicrositeCommand"
 }
 
@@ -201,7 +205,8 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           shareOnSocial = micrositeShareOnSocial.value
         ),
         templateTexts = MicrositeTemplateTexts(
-          footer = micrositeFooterText.value
+          footer = micrositeFooterText.value,
+          editButton = micrositeEditButtonText.value
         ),
         configYaml = configWithAllCustomVariables,
         fileLocations = MicrositeFileLocations(

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -152,11 +152,12 @@ trait MicrositeKeys {
     "Optional. Customize the second line in the footer."
   )
 
-  val micrositeEditButtonText: SettingKey[Option[String]] = settingKey[Option[String]](
-    "Optional. Add a button with given string in DocsLayout pages that links to the file in the repository."
-  )
-
   val publishMicrositeCommandKey: String = "publishMicrositeCommand"
+
+  val micrositeEditButton: SettingKey[Option[MicrositeEditButton]] =
+    settingKey[Option[MicrositeEditButton]](
+      "Optional. Add a button in DocsLayout pages that links to the file in the repository."
+    )
 }
 
 object MicrositeKeys extends MicrositeKeys
@@ -205,8 +206,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           shareOnSocial = micrositeShareOnSocial.value
         ),
         templateTexts = MicrositeTemplateTexts(
-          footer = micrositeFooterText.value,
-          editButton = micrositeEditButtonText.value
+          micrositeFooterText.value
         ),
         configYaml = configWithAllCustomVariables,
         fileLocations = MicrositeFileLocations(
@@ -250,6 +250,9 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           gitHostingUrl = micrositeGitHostingUrl.value,
           gitSidecarChat = micrositeGitterChannel.value,
           gitSidecarChatUrl = micrositeGitterChannelUrl.value
+        ),
+        editButtonSettings = MicrositeEditButtonSettings(
+          micrositeEditButton.value
         )
       ))
   }

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -108,7 +108,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := s"${micrositeGithubOwner.value}/${micrositeGithubRepo.value}",
     micrositeFooterText := Some(layouts.Layout.footer.toString),
-    micrositeEditButtonText := None,
+    micrositeEditButton := None,
     micrositeGithubLinks := true,
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
     includeFilter in Jekyll := (includeFilter in makeSite).value,

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -108,6 +108,7 @@ object MicrositesPlugin extends AutoPlugin {
     micrositeGitterChannel := true,
     micrositeGitterChannelUrl := s"${micrositeGithubOwner.value}/${micrositeGithubRepo.value}",
     micrositeFooterText := Some(layouts.Layout.footer.toString),
+    micrositeEditButtonText := None,
     micrositeGithubLinks := true,
     includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.jpeg" | "*.gif" | "*.js" | "*.swf" | "*.md" | "*.webm" | "*.ico" | "CNAME" | "*.yml" | "*.svg" | "*.json",
     includeFilter in Jekyll := (includeFilter in makeSite).value,

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -92,7 +92,8 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
         ),
         div(id := "content", data("github-owner") := config.gitSettings.githubOwner, data("github-repo") := config.gitSettings.githubRepo,
           div(cls := "content-wrapper",
-            section("{{ content }}")
+            section("{{ content }}"),
+            editButton
           )
         )
       )
@@ -155,4 +156,21 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
       (if (config.micrositeKazariSettings.micrositeKazariEnabled)
          List(script(src := "{{ site.baseurl }}/js/kazari.js"))
        else List.empty[TypedTag[String]])
+
+  def editButton: Seq[TypedTag[String]] =
+    config.templateTexts.editButton match {
+      case Some(text) =>
+        Seq(
+          div(
+            cls := "edit-button",
+            a(
+              href := config.gitSiteUrl,
+              href := "/edit/master/modules/docs/src/main/tut/{{ page.path }}",
+              cls := "btn-sm btn-info",
+              text
+            )
+          )
+        )
+      case None => Nil
+    }
 }

--- a/src/main/scala/microsites/layouts/DocsLayout.scala
+++ b/src/main/scala/microsites/layouts/DocsLayout.scala
@@ -157,20 +157,19 @@ class DocsLayout(config: MicrositeSettings) extends Layout(config) {
          List(script(src := "{{ site.baseurl }}/js/kazari.js"))
        else List.empty[TypedTag[String]])
 
-  def editButton: Seq[TypedTag[String]] =
-    config.templateTexts.editButton match {
-      case Some(text) =>
-        Seq(
+  def editButton: Option[TypedTag[String]] =
+    config.editButtonSettings.button match {
+      case Some(button) =>
+        Some(
           div(
             cls := "edit-button",
             a(
               href := config.gitSiteUrl,
-              href := "/edit/master/modules/docs/src/main/tut/{{ page.path }}",
+              href := button.basePath,
               cls := "btn-sm btn-info",
-              text
+              button.text
             )
-          )
-        )
-      case None => Nil
+          ))
+      case _ => None
     }
 }

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -79,7 +79,7 @@ case class MicrositeVisualSettings(
     favicons: Seq[MicrositeFavicon],
     shareOnSocial: Boolean)
 
-case class MicrositeTemplateTexts(footer: Option[String])
+case class MicrositeTemplateTexts(footer: Option[String], editButton: Option[String])
 
 case class MicrositeSettings(
     identity: MicrositeIdentitySettings,

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -79,7 +79,11 @@ case class MicrositeVisualSettings(
     favicons: Seq[MicrositeFavicon],
     shareOnSocial: Boolean)
 
-case class MicrositeTemplateTexts(footer: Option[String], editButton: Option[String])
+case class MicrositeTemplateTexts(footer: Option[String])
+
+case class MicrositeEditButton(text: String, basePath: String)
+
+case class MicrositeEditButtonSettings(button: Option[MicrositeEditButton])
 
 case class MicrositeSettings(
     identity: MicrositeIdentitySettings,
@@ -89,6 +93,7 @@ case class MicrositeSettings(
     fileLocations: MicrositeFileLocations,
     urlSettings: MicrositeUrlSettings,
     gitSettings: MicrositeGitSettings,
+    editButtonSettings: MicrositeEditButtonSettings,
     micrositeKazariSettings: KazariSettings) {
 
   def gitSiteUrl: String = {

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -18,11 +18,10 @@ package microsites.util
 
 import java.io.File
 
-import microsites.MicrositeKeys.{micrositeEditButton, _}
+import microsites.MicrositeKeys._
 import microsites._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
-import sbt.Resolver
 
 trait Arbitraries {
 
@@ -103,6 +102,13 @@ trait Arbitraries {
     } yield MicrositeFavicon(filename, size)
   }
 
+  implicit def micrositeEditButtonArbitrary: Arbitrary[Option[MicrositeEditButton]] = Arbitrary {
+    for {
+      text     <- Arbitrary.arbitrary[String]
+      basePath <- Arbitrary.arbitrary[String]
+    } yield Some(MicrositeEditButton(text, basePath))
+  }
+
   implicit def settingsArbitrary: Arbitrary[MicrositeSettings] = Arbitrary {
     for {
       name                                   ← Arbitrary.arbitrary[String]
@@ -148,7 +154,7 @@ trait Arbitraries {
       micrositeKazariDependencies            ← dependenciesListArbitrary.arbitrary
       micrositeKazariResolvers               ← Arbitrary.arbitrary[Seq[String]]
       micrositeFooterText                    ← Arbitrary.arbitrary[Option[String]]
-      micrositeEditButton                    ← Arbitrary.arbitrary[Option[MicrositeEditButton]]
+      micrositeEditButton                    ← micrositeEditButtonArbitrary.arbitrary
     } yield
       MicrositeSettings(
         MicrositeIdentitySettings(

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -148,6 +148,7 @@ trait Arbitraries {
       micrositeKazariDependencies            ← dependenciesListArbitrary.arbitrary
       micrositeKazariResolvers               ← Arbitrary.arbitrary[Seq[String]]
       micrositeFooterText                    ← Arbitrary.arbitrary[Option[String]]
+      micrositeEditButtonText                ← Arbitrary.arbitrary[Option[String]]
     } yield
       MicrositeSettings(
         MicrositeIdentitySettings(
@@ -165,7 +166,10 @@ trait Arbitraries {
           palette,
           favicon,
           shareOnSocial),
-        MicrositeTemplateTexts(micrositeFooterText),
+        MicrositeTemplateTexts(
+          micrositeFooterText,
+          micrositeEditButtonText
+        ),
         micrositeConfigYaml,
         MicrositeFileLocations(
           micrositeImgDirectory,

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -18,7 +18,7 @@ package microsites.util
 
 import java.io.File
 
-import microsites.MicrositeKeys._
+import microsites.MicrositeKeys.{micrositeEditButton, _}
 import microsites._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen._
@@ -148,7 +148,7 @@ trait Arbitraries {
       micrositeKazariDependencies            ← dependenciesListArbitrary.arbitrary
       micrositeKazariResolvers               ← Arbitrary.arbitrary[Seq[String]]
       micrositeFooterText                    ← Arbitrary.arbitrary[Option[String]]
-      micrositeEditButtonText                ← Arbitrary.arbitrary[Option[String]]
+      micrositeEditButton                    ← Arbitrary.arbitrary[Option[MicrositeEditButton]]
     } yield
       MicrositeSettings(
         MicrositeIdentitySettings(
@@ -167,8 +167,7 @@ trait Arbitraries {
           favicon,
           shareOnSocial),
         MicrositeTemplateTexts(
-          micrositeFooterText,
-          micrositeEditButtonText
+          micrositeFooterText
         ),
         micrositeConfigYaml,
         MicrositeFileLocations(
@@ -196,6 +195,9 @@ trait Arbitraries {
           gitHostingUrl,
           gitSidecarChat,
           gitSidecarChatUrl),
+        MicrositeEditButtonSettings(
+          micrositeEditButton
+        ),
         KazariSettings(
           micrositeKazariEnabled,
           micrositeKazariEvaluatorUrl,


### PR DESCRIPTION
for #96 

I added a configuration setting named `micrositeEditButtonText`. By default it's set to None and the button is not visible. If it's set to Some with a string a button will appear at the bottom of pages with the DocsLayout. The button will have the text of the given string and link to the edit view of the page in the project repository.

For example for the page https://www.vinyldns.io/api/create-zone.html the button would link to https://github.com/VinylDNS/vinyldns/edit/master/modules/docs/src/main/tut/api/create-zone.md

Desktop view:
<img width="1222" alt="screen shot 2018-10-05 at 12 03 09 pm" src="https://user-images.githubusercontent.com/4439228/46551528-07747880-c8a6-11e8-8071-a9fed820172d.png">

Mobile view.
<img width="409" alt="screen shot 2018-10-05 at 12 03 23 pm" src="https://user-images.githubusercontent.com/4439228/46551519-004d6a80-c8a6-11e8-8ba5-3b939aadc3d2.png">
