### PR TITLE
Fix twitter image URL

### DIFF
--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -125,7 +125,7 @@ abstract class Layout(config: MicrositeSettings) {
         `type` := "image/png",
         href := "{{site.url}}{{site.baseurl}}/img/favicon.png"),
       meta(name := "twitter:title", content := pageTitle),
-      meta(name := "twitter:image", content := s"${config.identity.homepage}img/poster.png"),
+      meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
       meta(name := "twitter:description", content := config.identity.description),
       meta(name := "twitter:card", content := "summary_large_image")
     ) ++ twitter.toList ++ twitterCreator.toList ++ kazariDep.toList ++ kazariRes.toList


### PR DESCRIPTION
I was wondering why img/poster.png was not shown on Twitter for my web page https://wvlet.org/airframe/, generated by sbt-microsites. 

twitter:image tag was pointing to the `img/poster.png`, not `(site.url)/(site.baseurl)/img/poster.png`

By using the same image path with `og:image` meta tag, we can fix this image link path. 