### PR TITLE
Use the site absolute url for twitter:image

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -34,6 +34,12 @@ micrositeName := "Your Awesome Library Name"
 micrositeDescription := "This is the description of my Awesome Library"
 ```
 
+- `micrositeUrl`: the URL prefix of your site. This setting is necessary if you need to show a poster image `{micrositeUrl}{micrositeBaseUrl}/img/poster.png` of your site on Twitter. See also [Twitter Cards](https://cards-dev.twitter.com/validator) for more details.
+
+```
+micrositeUrl := "http://yourdomain.io"
+```
+
 - `micrositeBaseUrl`: this setting brings the ability to set up a site base URL for your microsite. It's empty by default. However, you might need something like this:
 
 ```

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -71,6 +71,7 @@ trait MicrositeKeys {
   val micrositeShareOnSocial: SettingKey[Boolean] = settingKey[Boolean](
     "Optional. Includes links to share on social media in the layout. Enabled by default."
   )
+  val micrositeUrl: SettingKey[String]     = settingKey[String]("Microsite site absolute url prefix")
   val micrositeBaseUrl: SettingKey[String] = settingKey[String]("Microsite site base url")
   val micrositeDocumentationUrl: SettingKey[String] =
     settingKey[String]("Microsite site documentation url")
@@ -223,6 +224,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositePluginsDirectory = micrositePluginsDirectory.value
         ),
         urlSettings = MicrositeUrlSettings(
+          micrositeUrl = micrositeUrl.value,
           micrositeBaseUrl = micrositeBaseUrl.value,
           micrositeDocumentationUrl = micrositeDocumentationUrl.value,
           micrositeDocumentationLabelDescription = micrositeDocumentationLabelDescription.value

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -59,6 +59,7 @@ object MicrositesPlugin extends AutoPlugin {
       else
         organizationHomepage.value.map(_.toString).getOrElse("")
     },
+    micrositeUrl := "",
     micrositeBaseUrl := "",
     micrositeDocumentationUrl := "",
     micrositeDocumentationLabelDescription := "Documentation",

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -125,7 +125,10 @@ abstract class Layout(config: MicrositeSettings) {
         `type` := "image/png",
         href := "{{site.url}}{{site.baseurl}}/img/favicon.png"),
       meta(name := "twitter:title", content := pageTitle),
-      meta(name := "twitter:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+      meta(
+        name := "twitter:image",
+        // Twitter image URL must be the absolute path
+        content := s"${config.urlSettings.micrositeUrl}{{site.baseurl}}/img/poster.png"),
       meta(name := "twitter:description", content := config.identity.description),
       meta(name := "twitter:card", content := "summary_large_image")
     ) ++ twitter.toList ++ twitterCreator.toList ++ kazariDep.toList ++ kazariRes.toList

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -121,6 +121,8 @@ abstract class Layout(config: MicrositeSettings) {
         attr("property") := "og:image",
         content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
       meta(name := "og:title", content := pageTitle),
+      // For Linked-In
+      meta(name := "title", attr("property") := "og:title", content := pageTitle),
       meta(name := "og:site_name", content := config.identity.name),
       meta(name := "og:url", content := config.identity.homepage),
       meta(name := "og:type", content := "website"),

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -115,6 +115,11 @@ abstract class Layout(config: MicrositeSettings) {
       meta(name := "author", content := config.identity.author),
       meta(name := "description", content := config.identity.description),
       meta(name := "og:image", content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
+      // Linked-In requires this og:image tag format
+      meta(
+        name := "image",
+        attr("property") := "og:image",
+        content := "{{site.url}}{{site.baseurl}}/img/poster.png"),
       meta(name := "og:title", content := pageTitle),
       meta(name := "og:site_name", content := config.identity.name),
       meta(name := "og:url", content := config.identity.homepage),

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -66,6 +66,7 @@ case class MicrositeGitSettings(
     gitSidecarChatUrl: String)
 
 case class MicrositeUrlSettings(
+    micrositeUrl: String,
     micrositeBaseUrl: String,
     micrositeDocumentationUrl: String,
     micrositeDocumentationLabelDescription: String)

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -133,6 +133,7 @@ trait Arbitraries {
       micrositeExtraMdFiles                  ← markdownMapArbitrary.arbitrary
       micrositeExtraMdFilesOutput            ← Arbitrary.arbitrary[File]
       micrositePluginsDirectory              ← Arbitrary.arbitrary[File]
+      micrositeUrl                           ← Arbitrary.arbitrary[String]
       micrositeBaseUrl                       ← Arbitrary.arbitrary[String]
       micrositeDocumentationUrl              ← Arbitrary.arbitrary[String]
       micrositeDocumentationLabelDescription ← Arbitrary.arbitrary[String]
@@ -190,6 +191,7 @@ trait Arbitraries {
           micrositePluginsDirectory
         ),
         MicrositeUrlSettings(
+          micrositeUrl,
           micrositeBaseUrl,
           micrositeDocumentationUrl,
           micrositeDocumentationLabelDescription),


### PR DESCRIPTION
#283 didn't truly fix the issue because Twitter requires absolute URLs for images.

This PR adds a new configuration `micrositeUrl` when we need to specify the site absolute url. 

**Alternative approaches:**
- Setting `site.url`. But if we set this value in _config.yml, it makes difficult to see local images updates because there are many templates using `{{site.url}}` (e.g., favicon URLs), so all icon images refer remote server URLs.
- Using a twitter-card specific configuration (e.g., micrositeTwitterCardImageAbsoluteUrl)

With this fix, the card validator https://cards-dev.twitter.com/validator of Twitter icon can properly show the card image (/image/poster.png):
![image](https://user-images.githubusercontent.com/57538/48679719-97b20880-eb48-11e8-851f-79704a7c0ec3.png)
