### PR TITLE
upgrade tut to 0.6.9

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -40,7 +40,7 @@ object ProjectPlugin extends AutoPlugin {
 
         val (tutPluginVersion, scrimageVersion) = sbtBinaryVersionValue match {
           case "0.13" => ("0.5.6", "2.1.7")
-          case "1.0"  => ("0.6.6", "2.1.8")
+          case "1.0"  => ("0.6.9", "2.1.8")
         }
 
         Seq(


### PR DESCRIPTION
typelevel algebra wants a version that can build against scala 2.13.0-M5 (see typelevel/algebra#221)