### PR TITLE
fix typo with bumping ruby version to 2.3.0 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.8 --install --fuzzy
+  - rvm use 2.3.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/docs/src/main/tut/docs/index.md
+++ b/docs/src/main/tut/docs/index.md
@@ -39,7 +39,7 @@ This is needed in order to install and be able to use the `jekyll` gem from othe
 
 ```bash
 install:
-  - rvm use 2.2.8 --install --fuzzy
+  - rvm use 2.3.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -v 3.2.1

--- a/docs/src/main/tut/docs/publish-with-travis.md
+++ b/docs/src/main/tut/docs/publish-with-travis.md
@@ -96,7 +96,7 @@ before_install:
   scripts/decrypt-keys.sh; fi
 - export PATH=${PATH}:./vendor/bundle
 install:
-- rvm use 2.2.8 --install --fuzzy
+- rvm use 2.3.0 --install --fuzzy
 - gem update --system
 - gem install sass
 - gem install jekyll -v 3.2.1

--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -163,7 +163,7 @@ micrositeHighlightTheme := "monokai"
 - `micrositeHighlightLanguages`: by default, Highlight.js is configured to support syntax highlighting for `java`, `scala` and `bash`. You can add additional languages:
 
 ```
-micrositeHighlightTheme ++= Seq("protobuf", "thrift")
+micrositeHighlightLanguages ++= Seq("protobuf", "thrift")
 ```
 
 Then, use it as follows:


### PR DESCRIPTION
fix typo, and the following rubygems-update error incidentally:
https://travis-ci.org/47deg/sbt-microsites/jobs/469938515
https://travis-ci.org/47deg/sbt-microsites/jobs/469938514