### PR TITLE
Releases 0.9.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ import sbt.Resolver.sonatypeRepo
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
 
 addSbtPlugin("com.47deg"        % "sbt-org-policies" % "0.11.1")
-addSbtPlugin("com.47deg"        % "sbt-microsites"   % "0.8.0")
+addSbtPlugin("com.47deg"        % "sbt-microsites"   % "0.9.0-M1")
 addSbtPlugin("com.eed3si9n"     % "sbt-buildinfo"    % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site"         % "1.3.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages"      % "0.6.2")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.0-SNAPSHOT"
+version in ThisBuild := "0.9.0"


### PR DESCRIPTION
M1 is working as expected, so we are ready to release a new minor version of the library where the build is now fully upgraded.

**0.9.0** would be identical to **0.9.0-M1**.