### PR TITLE
Supporting ExtraMDFiles with Mdoc

### DIFF
--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -256,13 +256,13 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       .copyConfigurationFile((sourceDirectory in Jekyll).value, siteDirectory.value),
     micrositeMakeExtraMdFiles := micrositeHelper.value.buildAdditionalMd(),
     micrositeTutExtraMdFiles := {
-      val r: ScalaRun = (runner in Tut).value
-      val in          = micrositeMakeExtraMdFiles.value
-      val out         = tutTargetDirectory.value
-      val cp          = (fullClasspath in Tut).value
-      val opts        = (scalacOptions in Tut).value
-      val pOpts       = tutPluginJars.value.map(f => "–Xplugin:" + f.getAbsolutePath)
-      val re          = tutNameFilter.value.pattern.toString
+      val r     = (runner in Tut).value
+      val in    = micrositeMakeExtraMdFiles.value
+      val out   = tutTargetDirectory.value
+      val cp    = (fullClasspath in Tut).value
+      val opts  = (scalacOptions in Tut).value
+      val pOpts = tutPluginJars.value.map(f => "–Xplugin:" + f.getAbsolutePath)
+      val re    = tutNameFilter.value.pattern.toString
       _root_.tut.TutPlugin.tutOne(streams.value, r, in, out, cp, opts, pOpts, re).map(_._1)
     },
     makeTut := {

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -68,8 +68,6 @@ trait MicrositeKeys {
     taskKey[File]("Create microsite extra md files")
   val micrositeTutExtraMdFiles: TaskKey[Seq[File]] =
     taskKey[Seq[File]]("Run tut for extra microsite md files")
-  val micrositeMdocExtraMdFiles: TaskKey[Seq[File]] =
-    taskKey[Seq[File]]("Run mdoc for extra microsite md files")
   val micrositeName: SettingKey[String]        = settingKey[String]("Microsite name")
   val micrositeDescription: SettingKey[String] = settingKey[String]("Microsite description")
   val micrositeAuthor: SettingKey[String]      = settingKey[String]("Microsite author")
@@ -218,7 +216,10 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
           micrositeDataDirectory = micrositeDataDirectory.value,
           micrositeStaticDirectory = micrositeStaticDirectory.value,
           micrositeExtraMdFiles = micrositeExtraMdFiles.value,
-          micrositeExtraMdFilesOutput = micrositeExtraMdFilesOutput.value,
+          micrositeExtraMdFilesOutput = micrositeCompilingDocsTool.value match {
+            case WithTut  => micrositeExtraMdFilesOutput.value
+            case WithMdoc => tutTargetDirectory.value
+          },
           micrositePluginsDirectory = micrositePluginsDirectory.value
         ),
         urlSettings = MicrositeUrlSettings(
@@ -264,12 +265,6 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       val re          = tutNameFilter.value.pattern.toString
       _root_.tut.TutPlugin.tutOne(streams.value, r, in, out, cp, opts, pOpts, re).map(_._1)
     },
-    micrositeMdocExtraMdFiles := {
-
-
-
-      tutTargetDirectory.value
-    },
     makeTut := {
       Def.sequential(microsite, tut, micrositeTutExtraMdFiles, makeSite, micrositeConfig)
     }.value,
@@ -277,7 +272,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       Def.sequential(
         microsite,
         mdoc.toTask(""),
-        micrositeMdocExtraMdFiles,
+        micrositeMakeExtraMdFiles,
         makeSite,
         micrositeConfig)
     }.value,

--- a/src/sbt-test/microsites/mdoc-extra-md-files/CONSEQUAT.md
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/CONSEQUAT.md
@@ -1,0 +1,3 @@
+# Consequat Overview
+
+Consequat is another random file, located in the project's root.

--- a/src/sbt-test/microsites/mdoc-extra-md-files/README.md
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/README.md
@@ -1,0 +1,3 @@
+# Overview
+
+README file of the project, located in the project's root.

--- a/src/sbt-test/microsites/mdoc-extra-md-files/build.sbt
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/build.sbt
@@ -1,0 +1,39 @@
+import microsites.ExtraMdFileConfig
+enablePlugins(MicrositesPlugin)
+scalaVersion := sys.props("scala.version")
+micrositeCompilingDocsTool := WithMdoc
+
+micrositeExtraMdFiles := Map(
+  file("README.md") -> ExtraMdFileConfig(
+    "readme.md",
+    "home"
+  ),
+  file("CONSEQUAT.md") -> ExtraMdFileConfig(
+    "consequat.md",
+    "page",
+    Map("title" -> "Consequata", "section" -> "consequata", "position" -> "1")
+  )
+)
+
+def getLines(fileName: String) =
+  IO.readLines(file(fileName))
+
+lazy val checkReadme = TaskKey[Unit]("checkReadme")
+
+checkReadme := {
+  val lines =
+    getLines("target/scala-2.12/resource_managed/main/jekyll/readme.md")
+
+  if (!lines(1).contains("home"))
+    sys.error("Readme file has not layout home")
+}
+
+lazy val checkConsequat = TaskKey[Unit]("checkConsequat")
+
+checkConsequat := {
+  val lines =
+    getLines("target/scala-2.12/resource_managed/main/jekyll/consequat.md")
+
+  if (!lines(1).contains("page"))
+    sys.error("Consequat file has not layout page")
+}

--- a/src/sbt-test/microsites/mdoc-extra-md-files/docs/index.md
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/docs/index.md
@@ -1,0 +1,24 @@
+---
+layout: home
+---
+
+# Header 1
+
+Quisque sed lorem eu neque sollicitudin scelerisque ut id nisl. 
+
+Nunc et nunc vel tortor eleifend rutrum ut hendrerit ipsum. 
+
+> Suspendisse et blandit magna.
+
+```scala mdoc
+val list = List(1, 2, 3)
+list map (_ * 2)
+```
+
+Suspendisse sed faucibus ex. Aliquam at ultrices lacus, sit amet tempus augue. Fusce facilisis tincidunt tortor, nec ultrices tortor egestas sed. 
+
+## Header 2
+
+Vivamus in nisi laoreet, mattis erat eget, ornare ligula. Aliquam rhoncus lorem ac hendrerit sagittis. In hac habitasse platea dictumst. 
+
+Maecenas ut facilisis eros. Proin nisl urna, pharetra ut semper convallis, consequat aliquam turpis. Nam a magna varius, egestas nisl nec, pharetra sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Praesent libero magna, ornare nec odio id, cursus porta ante. Maecenas volutpat, neque eget bibendum faucibus, sapien nisi tincidunt eros, eu scelerisque lorem ante vel justo. Nullam euismod dolor sed lacus dapibus, dictum egestas dolor accumsan.

--- a/src/sbt-test/microsites/mdoc-extra-md-files/project/plugins.sbt
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("com.47deg" % "sbt-microsites" % sys.props("plugin.version"))

--- a/src/sbt-test/microsites/mdoc-extra-md-files/test
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/test
@@ -1,0 +1,17 @@
+# check that the sbt-microsites plugin work fine when mdoc compiles a markdown file
+
+> makeMicrosite
+
+# check markdown resource_managed/main/jekyll folder
+
+$ exists target/scala-2.12/resource_managed/main/jekyll/index.md
+
+# check site folder
+
+$ exists target/site/_config.yml
+$ exists target/site/index.html
+
+# check readme.md file
+#> checkReadme
+# check consequat.md file
+#> checkConsequat

--- a/src/sbt-test/microsites/mdoc-extra-md-files/test
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/test
@@ -12,6 +12,7 @@ $ exists target/site/_config.yml
 $ exists target/site/index.html
 
 # check readme.md file
-#> checkReadme
+> checkReadme
+
 # check consequat.md file
-#> checkConsequat
+> checkConsequat


### PR DESCRIPTION
This PR fixes #318 partially.

_Tut_ includes a very [convenient method](https://github.com/tpolecat/tut/blob/series%2F0.6.x/modules/plugin/src/main/scala/tut/TutPlugin.scala#L144) to compile a single markdown file, so the extra MD files are properly compiled and moved to Jekyll.

But in the case of _Mdoc_, currently it not including this feature, so at the moment, the solution I'm proposing in this PR is just moving the MD files to Jekyll (but the Mdoc areas are not compiled).

Maybe in the next iteration, we should swap the order of the syntax compiling, in order to move the extra MD files to the input directory, then compile them, and finally move them to the Jekyll folder. 
