### PR TITLE
Add {% raw %} directive to embedded {{page.path}}

### DIFF
--- a/docs/src/main/tut/docs/settings.md
+++ b/docs/src/main/tut/docs/settings.md
@@ -338,11 +338,11 @@ micrositeFooterText := Some("<b>Bob</b> the <i>Builder</i>")
 with the docs layout. The button links to the given path of the page in it's repository.
 By default, it is set to `None` and not visible. To enable, set the MicrositeEditButton with text
 for the button and the basePath for the file. The basePath is comprised of the file URL excluding the top-level
-repository URL and should include the dynamic property `{{page.path}}` that will be generated for each page when Jekyll
+repository URL and should include the dynamic property `{% raw %}{{page.path}}{% endraw %}` that will be generated for each page when Jekyll
 compiles the site.  **The strings are passed in unsanitized to the templating engine.**
 
 ```
-micrositeEditButton := Some(MicrositeEditButton("Improve this Page", "/edit/master/docs/src/main/tut/{{ page.path }}"))
+{% raw %}micrositeEditButton := Some(MicrositeEditButton("Improve this Page", "/edit/master/docs/src/main/tut/{{ page.path }}")){% endraw %}
 ```
 
 - `micrositeCompilingDocsTool`: Choose between compiling code snippets with [**tut**](https://github.com/tpolecat/tut) or [**mdoc**](https://github.com/scalameta/mdoc). By default, it's set to `WithTut` in order to preserve compatibility with previous versions of your markdown files. But `WithMdoc` and all the features it includes is now also supported.


### PR DESCRIPTION
Without this change, the `{{page.path}}` blocks actually resolve on the published microsite (from https://47deg.github.io/sbt-microsites/docs/settings.html):

![image](https://user-images.githubusercontent.com/69635/64128627-adf62180-cd74-11e9-9a65-61ed9eea11ef.png)


With the change it doesn't. Here's an example of what the results look like on my generated test site:

![image](https://user-images.githubusercontent.com/69635/64128596-90c15300-cd74-11e9-96a2-2c58790cb973.png)
