### PR TITLE
Use project scope for mdoc sources setting, not ThisBuild

### DIFF
--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -49,7 +49,7 @@ object MicrositesPlugin extends AutoPlugin {
         sourceDirectory in Jekyll := resourceManaged.value / "main" / "jekyll",
         tutSourceDirectory := sourceDirectory.value / "main" / "tut",
         tutTargetDirectory := resourceManaged.value / "main" / "jekyll",
-        mdocIn := baseDirectory.in(ThisBuild).value / "docs",
+        mdocIn := baseDirectory.value / "docs",
         mdocOut := resourceManaged.value / "main" / "jekyll",
       )
 


### PR DESCRIPTION
This fixes an issue in sbt-microsites where mdoc would always look for sources in a `docs` folder at the root of the sbt build, instead of a looking for it in the module's base directory.