### PR TITLE
Custom Sass/SCSS support

### DIFF
--- a/docs/docs/docs/build-the-microsite.md
+++ b/docs/docs/docs/build-the-microsite.md
@@ -20,9 +20,9 @@ If you're running the microsite locally, you can follow these steps:
 
 1. In a shell, navigate to the generated site directory in `target/site`.
 
-2. Start Jekyll with `jekyll serve`.
+2. Start Jekyll with `jekyll serve`. Bear in mind that depending on your `micrositeBaseUrl` setting, you might need to serve the site [setting the base url](https://jekyllrb.com/docs/configuration/options/#serve-command-options). Execute Jekyll appending that value `jekyll serve -b /yourbase_url`
 
-3. Navigate to [http://localhost:4000/yourbase_url/](http://localhost:4000/yourbase_url/) in your browser, where `yourbase_url` depends on your own preferences (see `micrositeBaseUrl` setting). Note, if you haven't specified any `micrositeBaseUrl` setting, it'll be empty by default so you can navigate to the site following this url [http://localhost:4000](http://localhost:4000/).  
+3. Navigate to [http://localhost:4000/](http://localhost:4000/) or [http://localhost:4000/yourbase_url/](http://localhost:4000/yourbase_url/) in your browser, where `yourbase_url` depends on your own preferences (see `micrositeBaseUrl` setting). Note, if you haven't specified any `micrositeBaseUrl` setting, it'll be empty by default.
 
 # Publish the microsite
 

--- a/docs/docs/docs/customize.md
+++ b/docs/docs/docs/customize.md
@@ -54,9 +54,13 @@ If you create your own images (which makes sense) and override the default ones,
 
 ## Styles
 
-`sbt-microsites` `pattern` style is completely based on [Bootstrap](https://getbootstrap.com/), adding some extra styles that make the microsites even more beautiful.
+`sbt-microsites` `pattern` style is completely based on [Bootstrap](https://getbootstrap.com/), adding some extra styles that make the microsites look great.
 
-That being said, you can personalize your microsite even further by using your own css files. In the same manner, as we've just seen for images, all the css files that you place in the directory associated with the `micrositeCssDirectory` setting (`src/main/resources/microsite/css` by default) will be copied to the generated microsite. Therefore, you can add new styles, or even override existing ones.
+That being said, you can personalize your microsite even further by using your own CSS files. In the same manner as we've just seen for images, all the css files that you place in the directory associated with the `micrositeCssDirectory` setting (`src/main/resources/microsite/css` by default) will be copied to the generated microsite. Therefore, you can add new styles, or even override existing ones.
+
+You can even use Sass/SCSS directly. For that, following [Jekyll Sass/SCSS support](https://jekyllrb.com/docs/assets/#sassscss), set all your partials in your _sass_ directory, which will be the one specified through the `micrositeSassDirectory` setting (`src/main/resources/microsite/sass` by default). Then, place your main SCSS files in the `micrositeCssDirectory` (`src/main/resources/microsite/css` by default). These main SCSS files need to include a dummy Front Matter section on them for Jekyll to read them properly (basically, any text enclosed by `---` will be valid).
+
+The files, CSS, or SCSS, will be processed and included in the layouts automatically.
 
 ## Colors
 

--- a/docs/docs/docs/settings.md
+++ b/docs/docs/docs/settings.md
@@ -191,6 +191,12 @@ micrositeImgDirectory := (resourceDirectory in Compile).value / "site" / "images
 micrositeCssDirectory := (resourceDirectory in Compile).value / "site" / "styles"
 ```
 
+- `micrositeSassDirectory`: If you want to use SCSS files, you might want to override the place to put the partials. This can be done through the `micrositeSassDirectory` setting. The main SCSS files need to go into the CSS directory, where they will be transformed into CSS files, and the partials will be loaded from this directory. The default value is `(resourceDirectory in Compile).value / "microsite" / "sass"`, but you can override it like this:
+
+```
+micrositeSassDirectory := (resourceDirectory in Compile).value / "site" / "partials"
+```
+
 - `micrositeJsDirectory`: You can also introduce custom javascript files in the generated microsite through the `micrositeJsDirectory` setting by using the same method. The javascript files in that folder will be automatically copied and imported by the plugin in your microsite. The default value is `(resourceDirectory in Compile).value / "microsite" / "js"`, but you can override it like this:
 
 ```

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -186,7 +186,13 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
         case _              => Nil
       }
 
-    val fullCssList = baseCssList ++ customCssList
+    val customScssList =
+      fr.fetchFilesRecursively(List(micrositeCssDirectory.value), validFile("scss")) match {
+        case Right(scssList) => scssList.map(scss => s"css/${scss.getName}")
+        case _               => Nil
+      }
+
+    val fullCssList = baseCssList ++ customCssList ++ customScssList
 
     val defaultYamlCustomVariables = Map(
       "name"        -> micrositeName.value,

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -95,6 +95,8 @@ trait MicrositeKeys {
     "Optional. Microsite images directory. By default, it'll be the resourcesDirectory + '/microsite/img'")
   val micrositeCssDirectory: SettingKey[File] = settingKey[File](
     "Optional. Microsite CSS directory. By default, it'll be the resourcesDirectory + '/microsite/css'")
+  val micrositeSassDirectory: SettingKey[File] = settingKey[File](
+    "Optional. Microsite SASS directory. By default, it'll be the resourcesDirectory + '/microsite/sass'")
   val micrositeJsDirectory: SettingKey[File] = settingKey[File](
     "Optional. Microsite Javascript directory. By default, it'll be the resourcesDirectory + '/microsite/js'")
   val micrositeCDNDirectives: SettingKey[CdnDirectives] = settingKey[CdnDirectives](
@@ -235,6 +237,7 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
         fileLocations = MicrositeFileLocations(
           micrositeImgDirectory = micrositeImgDirectory.value,
           micrositeCssDirectory = micrositeCssDirectory.value,
+          micrositeSassDirectory = micrositeSassDirectory.value,
           micrositeJsDirectory = micrositeJsDirectory.value,
           micrositeCDNDirectives = micrositeCDNDirectives.value,
           micrositeExternalLayoutsDirectory = micrositeExternalLayoutsDirectory.value,

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -299,15 +299,10 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       _root_.tut.TutPlugin.tutOne(streams.value, r, in, out, cp, opts, pOpts, re).map(_._1)
     },
     makeTut := {
-      Def.sequential(microsite, tut, micrositeTutExtraMdFiles, makeSite, micrositeConfig)
+      Def.sequential(microsite, tut, micrositeTutExtraMdFiles, makeSite)
     }.value,
     makeMdoc := {
-      Def.sequential(
-        microsite,
-        mdoc.toTask(""),
-        micrositeMakeExtraMdFiles,
-        makeSite,
-        micrositeConfig)
+      Def.sequential(microsite, mdoc.toTask(""), micrositeMakeExtraMdFiles, makeSite)
     }.value,
     makeMicrosite := Def.taskDyn {
       micrositeCompilingDocsTool.value match {

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -63,8 +63,6 @@ trait MicrositeKeys {
   val publishMicrosite: TaskKey[Unit] =
     taskKey[Unit]("Task helper that wraps the `publishMicrositeCommand`.")
   val microsite: TaskKey[Seq[File]] = taskKey[Seq[File]]("Create microsite files")
-  val micrositeConfig: TaskKey[Unit] =
-    taskKey[Unit]("Copy microsite config to the site folder")
   val micrositeMakeExtraMdFiles: TaskKey[File] =
     taskKey[File]("Create microsite extra md files")
   val micrositeTutExtraMdFiles: TaskKey[Seq[File]] =
@@ -285,8 +283,6 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
   lazy val micrositeTasksSettings = Seq(
     microsite := micrositeHelper.value.createResources(
       resourceManagedDir = (resourceManaged in Compile).value),
-    micrositeConfig := micrositeHelper.value
-      .copyConfigurationFile((sourceDirectory in Jekyll).value, siteDirectory.value),
     micrositeMakeExtraMdFiles := micrositeHelper.value.buildAdditionalMd(),
     micrositeTutExtraMdFiles := {
       val r     = (runner in Tut).value

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -206,8 +206,9 @@ trait MicrositeAutoImportSettings extends MicrositeKeys {
       "exclude"     -> List("css"),
       "include"     -> fullCssList,
       "sass" -> Map(
-        "style"     -> "compressed",
-        "sourcemap" -> "never",
+        "load_paths" -> List("_sass", "_sass_custom"),
+        "style"      -> "compressed",
+        "sourcemap"  -> "never",
       ),
       "collections" -> Map("tut" -> Map("output" -> true))
     )

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -45,7 +45,6 @@ object MicrositesPlugin extends AutoPlugin {
       micrositeTasksSettings ++
       Seq(
         git.remoteRepo := s"git@github.com:${micrositeGithubOwner.value}/${micrositeGithubRepo.value}.git",
-        mappings in Jekyll ++= micrositeHelper.value.directory("src/main/resources/microsite"),
         sourceDirectory in Jekyll := resourceManaged.value / "main" / "jekyll",
         tutSourceDirectory := sourceDirectory.value / "main" / "tut",
         tutTargetDirectory := resourceManaged.value / "main" / "jekyll",

--- a/src/main/scala/microsites/MicrositesPlugin.scala
+++ b/src/main/scala/microsites/MicrositesPlugin.scala
@@ -77,6 +77,7 @@ object MicrositesPlugin extends AutoPlugin {
       yamlPath = Some((resourceDirectory in Compile).value / "microsite" / "_config.yml")),
     micrositeImgDirectory := (resourceDirectory in Compile).value / "microsite" / "img",
     micrositeCssDirectory := (resourceDirectory in Compile).value / "microsite" / "css",
+    micrositeSassDirectory := (resourceDirectory in Compile).value / "microsite" / "sass",
     micrositeJsDirectory := (resourceDirectory in Compile).value / "microsite" / "js",
     micrositeCDNDirectives := CdnDirectives(),
     micrositeExternalLayoutsDirectory := (resourceDirectory in Compile).value / "microsite" / "layouts",

--- a/src/main/scala/microsites/layouts/Layout.scala
+++ b/src/main/scala/microsites/layouts/Layout.scala
@@ -144,6 +144,16 @@ abstract class Layout(config: MicrositeSettings) {
         case _ => Nil
       }
 
+    val customScssList =
+      fr.fetchFilesRecursively(List(config.fileLocations.micrositeCssDirectory), validFile("scss")) match {
+        case Right(scssList) =>
+          scssList.map(scss => {
+            val fileNameWithOutExt = scss.getName.replaceFirst("[.][^.]+$", "")
+            link(rel := "stylesheet", href := s"{{site.baseurl}}/css/${fileNameWithOutExt}.css")
+          })
+        case _ => Nil
+      }
+
     val customCDNList = config.fileLocations.micrositeCDNDirectives.cssList map { css =>
       link(rel := "stylesheet", href := css)
     }
@@ -177,7 +187,7 @@ abstract class Layout(config: MicrositeSettings) {
             href := s"{{site.baseurl}}/css/${config.visualSettings.theme}-style.css")
         )
 
-    cssStyles ++ customCssList ++ customCDNList ++ ganalytics.toList
+    cssStyles ++ customCssList ++ customScssList ++ customCDNList ++ ganalytics.toList
   }
 
   def scripts: List[TypedTag[String]] = {

--- a/src/main/scala/microsites/microsites.scala
+++ b/src/main/scala/microsites/microsites.scala
@@ -31,6 +31,7 @@ case class MicrositeIdentitySettings(
 case class MicrositeFileLocations(
     micrositeImgDirectory: File,
     micrositeCssDirectory: File,
+    micrositeSassDirectory: File,
     micrositeJsDirectory: File,
     micrositeCDNDirectives: CdnDirectives,
     micrositeExternalLayoutsDirectory: File,

--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -77,6 +77,9 @@ class MicrositeHelper(config: MicrositeSettings) {
       config.fileLocations.micrositeCssDirectory.getAbsolutePath,
       s"$targetDir$jekyllDir/css/")
     copyFilesRecursively(
+      config.fileLocations.micrositeSassDirectory.getAbsolutePath,
+      s"$targetDir$jekyllDir/_sass_custom/")
+    copyFilesRecursively(
       config.fileLocations.micrositeJsDirectory.getAbsolutePath,
       s"$targetDir$jekyllDir/js/")
     copyFilesRecursively(

--- a/src/sbt-test/microsites/config-yml/build.sbt
+++ b/src/sbt-test/microsites/config-yml/build.sbt
@@ -17,7 +17,7 @@ def getLines(fileName: String) =
 lazy val check = TaskKey[Unit]("check")
 
 check := {
-  val content = getLines("target/site/_config.yml").mkString
+  val content = getLines(s"${(resourceManaged in Compile).value}/jekyll/_config.yml").mkString
 
   if (!content.contains("org: Test"))
     sys.error("custom properties not found")

--- a/src/sbt-test/microsites/mdoc-compile/test
+++ b/src/sbt-test/microsites/mdoc-compile/test
@@ -8,5 +8,5 @@ $ exists target/scala-2.12/resource_managed/main/jekyll/index.md
 
 # check site folder
 
-$ exists target/site/_config.yml
+$ exists target/scala-2.12/resource_managed/main/jekyll/_config.yml
 $ exists target/site/index.html

--- a/src/sbt-test/microsites/mdoc-extra-md-files/test
+++ b/src/sbt-test/microsites/mdoc-extra-md-files/test
@@ -8,7 +8,7 @@ $ exists target/scala-2.12/resource_managed/main/jekyll/index.md
 
 # check site folder
 
-$ exists target/site/_config.yml
+$ exists target/scala-2.12/resource_managed/main/jekyll/_config.yml
 $ exists target/site/index.html
 
 # check readme.md file

--- a/src/sbt-test/microsites/microsites-config-keys/build.sbt
+++ b/src/sbt-test/microsites/microsites-config-keys/build.sbt
@@ -34,7 +34,7 @@ micrositePalette := Map(
 lazy val check = TaskKey[Unit]("check")
 
 check := {
-  val configFiles = IO.readLines(file("target/site/_config.yml"))
+  val configFiles = IO.readLines(file(s"${(resourceManaged in Compile).value}/jekyll/_config.yml"))
 
   configFiles foreach {
     case s if s.toString.startsWith("name") && !s.contains("test-microsite") =>

--- a/src/sbt-test/microsites/microsites-tasks/test
+++ b/src/sbt-test/microsites/microsites-tasks/test
@@ -20,6 +20,6 @@ $ exists target/scala-2.12/resource_managed/main/jekyll/js
 
 # check site folder
 
-$ exists target/site/_config.yml
+$ exists target/scala-2.12/resource_managed/main/jekyll/_config.yml
 $ exists target/site/css
 $ exists target/site/js

--- a/src/sbt-test/microsites/microsites-tasks/test
+++ b/src/sbt-test/microsites/microsites-tasks/test
@@ -6,8 +6,6 @@
 
 > makeSite
 
-> micrositeConfig
-
 # check resource_managed/main/jekyll folder
 
 $ exists target/scala-2.12/resource_managed/main/jekyll

--- a/src/sbt-test/microsites/tut-compile/test
+++ b/src/sbt-test/microsites/tut-compile/test
@@ -9,6 +9,6 @@ $ exists target/scala-2.12/resource_managed/main/jekyll/docs.md
 
 # check site folder
 
-$ exists target/site/_config.yml
+$ exists target/scala-2.12/resource_managed/main/jekyll/_config.yml
 $ exists target/site/index.html
 $ exists target/site/docs.html

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -105,6 +105,7 @@ trait Arbitraries {
       micrositeConfigYaml                    ← configYamlArbitrary.arbitrary
       micrositeImgDirectory                  ← Arbitrary.arbitrary[File]
       micrositeCssDirectory                  ← Arbitrary.arbitrary[File]
+      micrositeSassDirectory                 ← Arbitrary.arbitrary[File]
       micrositeJsDirectory                   ← Arbitrary.arbitrary[File]
       micrositeCDNDirectives                 <- cdnDirectivesArbitrary.arbitrary
       micrositeExternalLayoutsDirectory      ← Arbitrary.arbitrary[File]
@@ -155,6 +156,7 @@ trait Arbitraries {
         MicrositeFileLocations(
           micrositeImgDirectory,
           micrositeCssDirectory,
+          micrositeSassDirectory,
           micrositeJsDirectory,
           micrositeCDNDirectives,
           micrositeExternalLayoutsDirectory,


### PR DESCRIPTION
* Add `micrositeSassDirectory` setting.
* Add specific tasks to copy and process the SCSS and their partial files.
* Add specific _sass_ custom load path to Jekyll config.
* Remove config file copy, which breaks things when serving built sites.
* Add Sass/SCSS feature support documentation.

This closes #372 