### PR TITLE
Release version 1.0.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.8-SNAPSHOT"
+version in ThisBuild := "1.0.0"


### PR DESCRIPTION
## Release version 1.0.0


- Update `sbt` version in Travis, micrositeDocumentationUrl #383
- Update `scalatest` to 3.1.0 #381
- Update `scalactic` to 3.1.0 #380
- Multiversion support #379
- Update `sbt` to 1.3.4 #378 
- Changes micrositeExtraMdFilesOutput default folder #377
- Custom Sass/SCSS support #373
- Update `sbt-mdoc` to 2.0.2 #371
- Set homepage setting to be GitHub repo URL explicitely for the project #370 
- Site home change #368
- Streamline web 3rd party dependencies #367
- Modify `sbt-microsites` documentation folder #365
- Features layout section implementation #364
- Adds Java property `java.awt.headless=true` #363
- `mdoc` by default #362
- Use project scope for `mdoc` sources setting, not ThisBuild #357 by @pdalpra
- New style redesign #354