### PR TITLE
Airframe has graduated from sbt-microsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Many Scala projects, libraries, and applications use sbt-microsites to display d
 ![cron4s](https://alonsodomin.github.io/cron4s/img/navbar_brand.png) | [**cron4s**](https://alonsodomin.github.io/cron4s) | A CRON expression parser and AST for Scala
 ![freestyle](http://frees.io/img/navbar_brand.png) | [**freestyle**](http://frees.io/) | A cohesive & pragmatic framework of FP centric Scala libraries
 ![libra](https://to-ithaca.github.io/libra/img/navbar_brand.png) | [**libra**](https://to-ithaca.github.io/libra) |A dimensional analysis library based on dependent types
-![airframe](http://wvlet.org/airframe/img/navbar_brand.png) | [**Airframe**](http://wvlet.org/airframe) |A dependency injection library for Scala and Scala.js
 ![Scanamo](http://www.scanamo.org/img/navbar_brand.png) | [**Scanamo**](http://www.scanamo.org) | Simpler DynamoDB access for Scala
 ![Mocked Streams](https://mockedstreams.madewithtea.com/img/navbar_brand.png) | [**Mocked Streams**](https://mockedstreams.madewithtea.com) | Scala DSL for Unit-Testing Kafka Streams Topologies
 ![sbt-kubeyml](http://sbt-kubeyml.vaslabs.org/img/navbar_brand.png) | [**sbt-kubeyml**](http://sbt-kubeyml.vaslabs.org) | Typesafe Kubernetes manifests to deploy Scala applications 


### PR DESCRIPTION
During the major upgrade of sbt-microsite to 1.x, which introduced mdoc, we've tested several configurations that worked for our site. Then, we decided to switch to using mdoc and Docusaurus to fully customize our web site as we wish: https://wvlet.org/airframe/

I'd like to thank you for developing this plugin. sbt-microsite has worked for us for years. As the number of documentation pages and the volume increase, our doc site is no longer at a micro-scale, so the time has come for us to graduate from sbt-microsite.

Thank you for the wonderful plugin. We've learned a lot about how we should organize our documentation by following the standards provided by sbt-microsite. 