### PR TITLE
Remove hardcoded sbt version from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: scala
 dist: trusty
 jdk:
   - oraclejdk8
-
-matrix:
-  include:
-    - scala: 2.12.9
+scala:
+  - 2.12.9
 
 before_install:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ jdk:
 matrix:
   include:
     - scala: 2.12.9
-      env:
-        - SBT_VERSION=1.3.4
 
 before_install:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
@@ -19,22 +17,20 @@ install:
   - gem install jekyll -v 4
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION ^^$SBT_VERSION clean compile test
-  - sbt ++$TRAVIS_SCALA_VERSION ^^$SBT_VERSION scripted;
+  - sbt ++$TRAVIS_SCALA_VERSION clean compile test
+  - sbt ++$TRAVIS_SCALA_VERSION scripted;
 
 after_success:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
       if grep -q "SNAPSHOT" version.sbt; then
-        sbt ^^$SBT_VERSION publish;
+        sbt publish;
       else
-        if [ "$SBT_VERSION" = "1.3.4" ]; then
-          sbt ^^$SBT_VERSION orgUpdateDocFiles;
-          git reset --hard HEAD;
-          git clean -f;
-          git checkout master;
-          git pull origin master;
-          sbt ^^$SBT_VERSION release;
-          sbt ^^$SBT_VERSION docs/publishMicrosite;
-        fi
+        sbt orgUpdateDocFiles;
+        git reset --hard HEAD;
+        git clean -f;
+        git checkout master;
+        git pull origin master;
+        sbt release;
+        sbt docs/publishMicrosite;
       fi
     fi


### PR DESCRIPTION
I feel like this could be the culprit as to why the current 1.1.1 version has not been published, but I'm not totally sure, as some parts of the workflow has been completed but others don't:

https://repo1.maven.org/maven2/com/47deg/sbt-microsites_2.12_1.0/

:thinking: 