### PR TITLE
Declare proper doctype on layouts

### DIFF
--- a/src/main/scala/microsites/util/MicrositeHelper.scala
+++ b/src/main/scala/microsites/util/MicrositeHelper.scala
@@ -199,7 +199,7 @@ class MicrositeHelper(config: MicrositeSettings) {
         val targetPath = s"$targetDir$jekyllDir/_layouts/$layoutName.html"
         createFile(targetPath)
 
-        writeContentToFile(layout.render.toString(), targetPath)
+        writeContentToFile("<!DOCTYPE html>" + layout.render.toString(), targetPath)
         targetPath.toFile
     }
   }

--- a/src/test/scala/microsites/DocsLayoutTest.scala
+++ b/src/test/scala/microsites/DocsLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/HomeLayoutTest.scala
+++ b/src/test/scala/microsites/HomeLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/LayoutTest.scala
+++ b/src/test/scala/microsites/LayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/MenuPartialLayoutTest.scala
+++ b/src/test/scala/microsites/MenuPartialLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/PageLayoutTest.scala
+++ b/src/test/scala/microsites/PageLayoutTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/microsites/util/Arbitraries.scala
+++ b/src/test/scala/microsites/util/Arbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2016-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,61 +132,64 @@ trait Arbitraries {
       micrositeFooterText                    ← Arbitrary.arbitrary[Option[String]]
       micrositeEditButton                    ← micrositeEditButtonArbitrary.arbitrary
       micrositeVersionList                   ← Arbitrary.arbitrary[Seq[String]]
-    } yield
-      MicrositeSettings(
-        MicrositeIdentitySettings(
-          name,
-          description,
-          author,
-          homepage,
-          organizationHomepage,
-          twitter,
-          twitterCreator,
-          analytics),
-        MicrositeVisualSettings(
-          highlightTheme,
-          highlightLanguages,
-          palette,
-          favicon,
-          shareOnSocial,
-          theme),
-        MicrositeTemplateTexts(
-          micrositeFooterText
-        ),
-        micrositeConfigYaml,
-        MicrositeFileLocations(
-          micrositeImgDirectory,
-          micrositeCssDirectory,
-          micrositeSassDirectory,
-          micrositeJsDirectory,
-          micrositeCDNDirectives,
-          micrositeExternalLayoutsDirectory,
-          micrositeExternalIncludesDirectory,
-          micrositeDataDirectory,
-          micrositeStaticDirectory,
-          micrositeExtraMdFiles,
-          micrositeExtraMdFilesOutput,
-          micrositePluginsDirectory
-        ),
-        MicrositeUrlSettings(
-          micrositeUrl,
-          micrositeBaseUrl,
-          micrositeDocumentationUrl,
-          micrositeDocumentationLabelDescription),
-        MicrositeGitSettings(
-          githubOwner,
-          githubRepo,
-          githubLinks,
-          gitHostingService,
-          gitHostingUrl,
-          gitSidecarChat,
-          gitSidecarChatUrl),
-        MicrositeEditButtonSettings(
-          micrositeEditButton
-        ),
-        MicrositeMultiversionSettings(
-          micrositeVersionList
-        )
+    } yield MicrositeSettings(
+      MicrositeIdentitySettings(
+        name,
+        description,
+        author,
+        homepage,
+        organizationHomepage,
+        twitter,
+        twitterCreator,
+        analytics
+      ),
+      MicrositeVisualSettings(
+        highlightTheme,
+        highlightLanguages,
+        palette,
+        favicon,
+        shareOnSocial,
+        theme
+      ),
+      MicrositeTemplateTexts(
+        micrositeFooterText
+      ),
+      micrositeConfigYaml,
+      MicrositeFileLocations(
+        micrositeImgDirectory,
+        micrositeCssDirectory,
+        micrositeSassDirectory,
+        micrositeJsDirectory,
+        micrositeCDNDirectives,
+        micrositeExternalLayoutsDirectory,
+        micrositeExternalIncludesDirectory,
+        micrositeDataDirectory,
+        micrositeStaticDirectory,
+        micrositeExtraMdFiles,
+        micrositeExtraMdFilesOutput,
+        micrositePluginsDirectory
+      ),
+      MicrositeUrlSettings(
+        micrositeUrl,
+        micrositeBaseUrl,
+        micrositeDocumentationUrl,
+        micrositeDocumentationLabelDescription
+      ),
+      MicrositeGitSettings(
+        githubOwner,
+        githubRepo,
+        githubLinks,
+        gitHostingService,
+        gitHostingUrl,
+        gitSidecarChat,
+        gitSidecarChatUrl
+      ),
+      MicrositeEditButtonSettings(
+        micrositeEditButton
+      ),
+      MicrositeMultiversionSettings(
+        micrositeVersionList
       )
+    )
   }
 }


### PR DESCRIPTION
* Add a proper doctype declaration `<!DOCTYPE html>` to all layouts when they are generated thought the render method of their TypedTag.
* Update some copyright notices.

This closes #427 