### PR TITLE
Populate github owner/repo keys with default values from git remote

### DIFF
--- a/docs/docs/docs/build-the-microsite.md
+++ b/docs/docs/docs/build-the-microsite.md
@@ -54,7 +54,7 @@ From version [`0.5.4`](https://github.com/47deg/sbt-microsites/releases/tag/v0.5
 Before publishing, a couple of requirements should be satisfied:
 
 1. Initialize the **gh-pages** branch, you can follow the instructions defined in the [sbt-ghpages](https://github.com/sbt/sbt-ghpages/blob/master/README.md#initializing-the-gh-pages-branch) repository.
-2. Define `micrositeGithubOwner` and `micrositeGithubRepo` settings and maybe the `micrositePushSiteWith` and `micrositeGithubRepo` settings.
+2. Define `micrositeGithubOwner` and `micrositeGithubRepo` settings (if they can't be infered from git remotes) and maybe the `micrositePushSiteWith` and `micrositeGithubRepo` settings.
 You can see more details regarding this in the [Configuring the Microsite]({% link docs/settings.md %}) section.
 
 Once both requirements are satisfied, you can just run:

--- a/docs/docs/docs/settings.md
+++ b/docs/docs/docs/settings.md
@@ -95,7 +95,7 @@ micrositeTwitterCreator := "@47deg"
 ```
 
 
-- `micrositeGithubOwner` and `micrositeGithubRepo`: Used to add links to the `GitHub` repo. It's also needed for publishing the site when `github4s` is chosen (see `micrositePushSiteWith` setting). Both `micrositeGithubOwner` and `micrositeGithubRepo` are required:
+- `micrositeGithubOwner` and `micrositeGithubRepo`: Used to add links to the `GitHub` repo. It's also needed for publishing the site when `github4s` is chosen (see `micrositePushSiteWith` setting). Defaults to the information found in the 'origin' Git remote, if such remote exists; otherwise they must be set like:
 
 ```scala
 micrositeGithubOwner := "47deg"

--- a/src/main/scala/microsites/MicrositeKeys.scala
+++ b/src/main/scala/microsites/MicrositeKeys.scala
@@ -164,8 +164,12 @@ trait MicrositeKeys {
   val micrositeFavicons: SettingKey[Seq[MicrositeFavicon]] = settingKey[Seq[MicrositeFavicon]](
     "Optional. List of filenames and sizes for the PNG/ICO files to be used as favicon for the generated site, located in '/microsite/img'. The sizes should be described with a string (i.e.: \"16x16\"). By default, favicons with different sizes will be generated from the navbar_brand2x.jpg file."
   )
-  val micrositeGithubOwner: SettingKey[String] = settingKey[String]("Microsite Github owner")
-  val micrositeGithubRepo: SettingKey[String]  = settingKey[String]("Microsite Github repo")
+  val micrositeGithubOwner: SettingKey[String] = settingKey[String](
+    "Microsite Github owner, defaults to the information found in the 'origin' Git remote"
+  )
+  val micrositeGithubRepo: SettingKey[String] = settingKey[String](
+    "Microsite Github repo, defaults to the information found in the 'origin' Git remote"
+  )
   val micrositeGithubToken: SettingKey[Option[String]] =
     settingKey[Option[String]]("Microsite Github token for pushing the microsite")
   val micrositeGithubLinks: SettingKey[Boolean] = settingKey[Boolean](


### PR DESCRIPTION
# Why this change?

Most of the projects using this plugin use either Travis, Github Actions or other similar CIs. All these have in common that they set a git remote `origin` pointing to the original repository. We can extract that information from git to pre-populate the `micrositeGithubOwner` and `micrositeGithubRepo`.

# What has been done in this PR?

Populate by default the `micrositeGithubOwner` and `micrositeGithubRepo` with the information extracted from calling `git ls-remote --get-url origin`.