### PR TITLE
Set absolute position to main features img relative to parent container

### DIFF
--- a/src/main/resources/_sass/light-style/_features.scss
+++ b/src/main/resources/_sass/light-style/_features.scss
@@ -1,7 +1,7 @@
 // Features Header
 // -----------------------------------------------------
 .features-masthead {
-    padding: 130px 0;
+  padding: 130px 0;
 }
 
 .features-image {
@@ -10,6 +10,9 @@
   background: url("../img/features-header.svg") no-repeat;
   background-size: contain;
   background-position: center;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .feature-header {
@@ -18,6 +21,7 @@
   justify-content: space-between;
   height: 100%;
   width: 100%;
+  position: relative;
 
   .features-header-description {
     display: flex;


### PR DESCRIPTION
After https://github.com/47deg/sbt-microsites/pull/430 we lost the main image in the features layout, as the proper `doctype` makes that `background-image` needing another way of setting its height. 

This PR fixes that.